### PR TITLE
feat(piyasa-verisi): Yahoo Finance ile gercek borsa verisi entegrasyonu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@ CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 # --- Veritabani ---------------------------------------------------------
 # BOS birakilirsa repository katmani bellek ici veriyi kullanir (test/demo).
 # Doluysa db/v5_schema_and_data.sql semasi beklenir.
-# DATABASE_URL=postgresql://finans:finans@localhost:5432/finans
+#
+# BU DOSYA SABLONDUR VE GIT'E GIRER - buraya GERCEK sifre YAZMAYIN.
+# Gercek deger `backend/.env` icine yazilir (.gitignore'da, git'e girmez).
+# Surucu eki `+psycopg` ile yazilir; backend/README.md ve testler bu bicimi
+# kullanir (db/session.py ikisini de kabul eder).
+# DATABASE_URL=postgresql+psycopg://KULLANICI:SIFRE@HOST:5432/VERITABANI
 DB_ECHO=false
 
 # --- Kimlik dogrulama ---------------------------------------------------
@@ -43,18 +48,28 @@ SECURITY_MODEL=
 # "api" secili olsa bile Yahoo'ya ulasilamazsa veya gunluk kota dolarsa
 # saglayici otomatik simulatore duser; bu durumda price_history.source
 # "simulated" yazilir, yani sahte veri asla "gercek" etiketlenmez.
+#
+# PAYLASILAN VERITABANI UYARISI: DATABASE_URL ortak bir veritabanini (orn.
+# ekibin Supabase'i) gosteriyorsa backend'i lokalde acan HER gelistirici o
+# veritabanina fiyat yazar ve ayni Yahoo kotasini harcar. Yalnizca arayuzle
+# ugrasiyorsaniz MARKET_DATA_PROVIDER=simulated yapin veya
+# PRICE_TICK_SECONDS=0 ile fiyat gorevini tamamen kapatin.
 MARKET_DATA_PROVIDER=api
 
-# Fiyat gorevinin calisma araligi (saniye). 900 = 15 dakika.
-# Yahoo TEK istekte tum sembolleri getirdigi icin gunde ~96 cagri eder.
-# Daha sik calistirmak engellenme riskini artirir.
+# Fiyat gorevinin calisma araligi (saniye). 900 = 15 dakika -> gunde 96 tick.
+# 0 = fiyat gorevi hic baslamaz.
+#
+# DIKKAT: bir tick TEK istek DEGILDIR. yfinance her ticker icin ayri HTTP
+# istegi atar; 16 ticker x 96 tick = gunde ~1.536 istek. Araligi kisaltmak
+# istek sayisini dogru orantili buyutur ve engellenme riskini artirir.
 PRICE_TICK_SECONDS=900
 
 # Her N tick'te bir price_history'ye satir yazilir. 1 = her tick.
 PRICE_HISTORY_EVERY_N_TICKS=1
 
-# Gunluk dis API cagri tavani (market_api_usage tablosuyla takip edilir).
-MARKET_API_DAILY_QUOTA=400
+# Gunluk dis API ISTEK tavani (market_api_usage tablosuyla takip edilir).
+# Sayac ticker bazlidir: beklenen gunluk hacim ~1.536, tavan pay birakir.
+MARKET_API_DAILY_QUOTA=2500
 
 MARKET_SIM_SEED=20260813
 

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 # --- Veritabani ---------------------------------------------------------
 # BOS birakilirsa repository katmani bellek ici veriyi kullanir (test/demo).
 # Doluysa db/v5_schema_and_data.sql semasi beklenir.
-# DATABASE_URL=postgresql+psycopg://finans:finans@localhost:5432/finans
+# DATABASE_URL=postgresql://finans:finans@localhost:5432/finans
 DB_ECHO=false
 
 # --- Kimlik dogrulama ---------------------------------------------------
@@ -37,9 +37,25 @@ SYNTHESIZER_MODEL=
 SECURITY_MODEL=
 
 # --- Piyasa verisi katmani ----------------------------------------------
-# simulated (varsayilan) | api | hybrid — api/hybrid PO onayi gerektirir
-MARKET_DATA_PROVIDER=simulated
-PRICE_TICK_SECONDS=60
+# api (varsayilan) : Yahoo Finance'ten GERCEK fiyat (app/market/yahoo.py)
+# simulated        : rastgele yuruyus - ag gerektirmez, deterministik
+#
+# "api" secili olsa bile Yahoo'ya ulasilamazsa veya gunluk kota dolarsa
+# saglayici otomatik simulatore duser; bu durumda price_history.source
+# "simulated" yazilir, yani sahte veri asla "gercek" etiketlenmez.
+MARKET_DATA_PROVIDER=api
+
+# Fiyat gorevinin calisma araligi (saniye). 900 = 15 dakika.
+# Yahoo TEK istekte tum sembolleri getirdigi icin gunde ~96 cagri eder.
+# Daha sik calistirmak engellenme riskini artirir.
+PRICE_TICK_SECONDS=900
+
+# Her N tick'te bir price_history'ye satir yazilir. 1 = her tick.
+PRICE_HISTORY_EVERY_N_TICKS=1
+
+# Gunluk dis API cagri tavani (market_api_usage tablosuyla takip edilir).
+MARKET_API_DAILY_QUOTA=400
+
 MARKET_SIM_SEED=20260813
 
 # --- Orkestrasyon timeout ayarlari (bir ajan asilirsa istek dusmesin) ----

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -84,3 +84,54 @@ jobs:
             echo "::error::Veri katmani testleri atlandi — Postgres servisi calismiyor."
             exit 1
           fi
+
+  # `borsa-verisi/` backend'in DISINDA, bagimsiz bir betik klasorudur.
+  # AYRI JOB SART: yukaridaki job'in her adimi `working-directory: backend`
+  # oldugu icin bu klasordeki kod ve 44 test CI'da HIC kosmuyordu - yerelde
+  # gecseler de ilk bozulmada kimse haberdar olmazdi.
+  #
+  # Postgres servisi YOK: bu testler ag ve veritabani gerektirmez, hepsi saf
+  # mantik sinar (sembol eslemesi, metrik hesabi, SQL metni uretimi).
+  borsa-verisi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: borsa-verisi var mi kontrol et
+        id: check
+        run: |
+          if [ -f borsa-verisi/requirements.txt ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "borsa-verisi/requirements.txt bulundu."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "borsa-verisi/requirements.txt yok — adimlar atlaniyor."
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.check.outputs.exists == 'true'
+        with:
+          python-version: "3.13"
+
+      - name: Bagimliliklari kur
+        if: steps.check.outputs.exists == 'true'
+        working-directory: borsa-verisi
+        run: pip install -r requirements.txt
+
+      - name: Lint
+        if: steps.check.outputs.exists == 'true'
+        working-directory: borsa-verisi
+        run: ruff check .
+
+      - name: Format kontrolu
+        if: steps.check.outputs.exists == 'true'
+        working-directory: borsa-verisi
+        run: black --check .
+
+      - name: Test
+        if: steps.check.outputs.exists == 'true'
+        working-directory: borsa-verisi
+        # pytest hic test toplayamazsa 5 doner ve job kirmizi olur; yol/import
+        # bozulmasi sessizce "yesil" gorunmez.
+        run: pytest -q -rs

--- a/backend/app/api/routes/market.py
+++ b/backend/app/api/routes/market.py
@@ -23,13 +23,24 @@ async def assets(
     return await service.varliklar_getir(category)
 
 
+#: `borsa-verisi/` betigi Yahoo'dan varsayilan olarak 2 yillik gecmis ceker
+#: (`period=2y`); ust sinir bununla eslesir. Daha genis bir gecmis yuklenirse
+#: bu deger DE guncellenmelidir - aksi halde veri veritabaninda durur ama
+#: frontend'e hic ulasmaz.
+MAX_HISTORY_GUN = 730
+
+
 @router.get("/history", response_model=HistoryResponse)
 async def history(
     user: CurrentUser,
     symbol: str = Query(description="Varlik kodu (orn. THYAO)"),
-    days: int = Query(default=30, ge=1, le=365),
+    days: int = Query(default=30, ge=1, le=MAX_HISTORY_GUN),
 ) -> HistoryResponse:
-    """PriceChart icin ham fiyat serisi."""
+    """PriceChart icin ham fiyat serisi.
+
+    Gunluk/haftalik gorunum icin varsayilan 30 gun yeterlidir; frontend
+    yillik gorunum icin `days=365` veya `days=730` gonderebilir.
+    """
     return await service.gecmis_getir(symbol, days=days)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,9 +64,13 @@ class Settings(BaseSettings):
     # sahte veri hicbir zaman "gercek" olarak etiketlenmez.
     market_data_provider: str = "api"
 
-    #: Fiyat gorevinin calisma araligi. 15 dakika: Yahoo tek istekte tum
-    #: sembolleri getirdigi icin gunde ~96 cagri eder (kota tavaninin cok
-    #: altinda). Daha sik calistirmak engellenme riskini artirir.
+    #: Fiyat gorevinin calisma araligi. 15 dakika -> gunde 96 tick.
+    #:
+    #: DIKKAT: bir tick TEK istek DEGILDIR. yfinance her ticker icin ayri bir
+    #: HTTP istegi atar (bkz. `app/market/yahoo.py`), yani 16 ticker x 96 tick
+    #: = gunde ~1.536 istek. Bu araligi kisaltmak istek sayisini dogru orantili
+    #: buyutur ve yfinance resmi bir API olmadigi icin engellenme riskini
+    #: artirir.
     price_tick_seconds: int = 900
 
     market_sim_seed: int = 20260813
@@ -76,9 +80,14 @@ class Settings(BaseSettings):
     #: 5'ti; 15 dakikaya cikinca her tick'te yazmak makul cozunurluk verir.
     price_history_every_n_ticks: int = 1
 
-    #: Gunluk cagri tavani (kota korumasi). 96 tick/gun beklenir; tavan
-    #: yeniden baslatmalara ve elle calistirmalara pay birakir.
-    market_api_daily_quota: int = 400
+    #: Gunluk HTTP istegi tavani (kota korumasi). Sayac TICKER bazlidir.
+    #:
+    #: HESAP: 16 ticker x 96 tick = 1.536 istek/gun. Tavan yeniden
+    #: baslatmalara, elle calistirmalara ve ayni veritabanini paylasan birden
+    #: fazla gelistiriciye pay birakacak sekilde ~%60 ustune konuldu.
+    #: Onceki 400 degeri tick basina 1 sayildigi varsayimindan geliyordu ve
+    #: gercek hacmin dortte birinden azdi - tavan hic tetiklenmiyordu.
+    market_api_daily_quota: int = 2500
 
     # --- Timeout — bir ajan asilirsa tum istek dusmesin -------------------
     agent_timeout_seconds: int = 20

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,14 +56,28 @@ class Settings(BaseSettings):
     security_model: str = ""  # en kucuk/hizli model burada
 
     # --- Piyasa verisi katmani (mimari v4 bolum 8) ----------------------
-    # simulated: kota harcamaz, deterministik (demo varsayilani)
-    # api / hybrid: gercek saglayici - PO onayi ve lisans kontrolu gerekir
-    market_data_provider: str = "simulated"
-    price_tick_seconds: int = 60
+    # api       : Yahoo Finance'ten GERCEK fiyat (varsayilan)
+    # simulated : rastgele yuruyus - kota harcamaz, deterministik
+    #
+    # "api" secili olsa bile Yahoo'ya ulasilamazsa saglayici otomatik olarak
+    # simulatore duser ve `price_history.source` "simulated" yazilir; yani
+    # sahte veri hicbir zaman "gercek" olarak etiketlenmez.
+    market_data_provider: str = "api"
+
+    #: Fiyat gorevinin calisma araligi. 15 dakika: Yahoo tek istekte tum
+    #: sembolleri getirdigi icin gunde ~96 cagri eder (kota tavaninin cok
+    #: altinda). Daha sik calistirmak engellenme riskini artirir.
+    price_tick_seconds: int = 900
+
     market_sim_seed: int = 20260813
+
     #: Fiyat gorevi her N tick'te bir `price_history`'ye satir yazar.
-    price_history_every_n_ticks: int = 5
-    #: Ucretsiz API katmanlari icin gunluk cagri tavani (kota korumasi).
+    #: 1 = her tick (15 dakikada bir satir). Tick araligi 60 sn iken bu deger
+    #: 5'ti; 15 dakikaya cikinca her tick'te yazmak makul cozunurluk verir.
+    price_history_every_n_ticks: int = 1
+
+    #: Gunluk cagri tavani (kota korumasi). 96 tick/gun beklenir; tavan
+    #: yeniden baslatmalara ve elle calistirmalara pay birakir.
     market_api_daily_quota: int = 400
 
     # --- Timeout — bir ajan asilirsa tum istek dusmesin -------------------

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,21 +5,9 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 
-# WINDOWS NOTU: psycopg'nin async surucusu, asyncio'nun Windows'taki VARSAYILAN
-# event loop'u olan ProactorEventLoop ile calismaz - "Psycopg cannot use the
-# 'ProactorEventLoop' to run in async mode" hatasi verir.
-#
-# Duzeltme BILEREK burada DEGIL, `run.py` icindedir: `uvicorn app.main:app`
-# komutu kendi event loop'unu `asyncio.run()` ile olusturur, bu modulu ise
-# o loop'un ICINDE, gecikmeli olarak import eder (uvicorn'un `Config.load()`
-# mekanizmasi). Yani policy burada ayarlansa bile loop ZATEN kurulmus olur -
-# denendi, calismadi. `set_event_loop_policy` yalnizca uvicorn hic
-# BASLAMADAN once, ayri bir surecte calisan kodda etkilidir.
-#
-# Windows'ta yerel gelistirme icin: `uvicorn app.main:app` YERINE
-# `python run.py` calistirin (bkz. backend/run.py). Docker/Linux'ta (CI,
-# production) bu sorun hic yasanmaz, mevcut `uvicorn app.main:app` komutu
-# aynen kalir.
+# WINDOWS NOTU: event loop policy duzeltmesi bilerek BURADA DEGIL, `run.py`
+# icindedir - gerekcesi orada anlatilir. Windows'ta yerel gelistirme icin
+# `uvicorn app.main:app` yerine `python run.py` calistirin.
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,21 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 
+# WINDOWS NOTU: psycopg'nin async surucusu, asyncio'nun Windows'taki VARSAYILAN
+# event loop'u olan ProactorEventLoop ile calismaz - "Psycopg cannot use the
+# 'ProactorEventLoop' to run in async mode" hatasi verir.
+#
+# Duzeltme BILEREK burada DEGIL, `run.py` icindedir: `uvicorn app.main:app`
+# komutu kendi event loop'unu `asyncio.run()` ile olusturur, bu modulu ise
+# o loop'un ICINDE, gecikmeli olarak import eder (uvicorn'un `Config.load()`
+# mekanizmasi). Yani policy burada ayarlansa bile loop ZATEN kurulmus olur -
+# denendi, calismadi. `set_event_loop_policy` yalnizca uvicorn hic
+# BASLAMADAN once, ayri bir surecte calisan kodda etkilidir.
+#
+# Windows'ta yerel gelistirme icin: `uvicorn app.main:app` YERINE
+# `python run.py` calistirin (bkz. backend/run.py). Docker/Linux'ta (CI,
+# production) bu sorun hic yasanmaz, mevcut `uvicorn app.main:app` komutu
+# aynen kalir.
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/app/market/provider.py
+++ b/backend/app/market/provider.py
@@ -74,9 +74,11 @@ class SimulatedMarketProvider(MarketDataProvider):
 class ApiMarketProvider(MarketDataProvider):
     """Gercek piyasa verisi - Yahoo Finance (`app/market/yahoo.py`).
 
-    TEK ISTEK: Tum semboller `yf.download` ile TEK cagrida gelir. 15 dakikalik
-    tick ile gunde ~96 cagri eder; sembol basina ayri istek atilsaydi ~1.500
-    cagri olurdu ve yfinance resmi API olmadigi icin engellenme riski dogardi.
+    CAGRI SAYISI: `yf.download` tek bir fonksiyon cagrisi gibi gorunse de
+    iceride HER TICKER icin ayri bir HTTP istegi atar (bkz. `yahoo.py` modul
+    docstring'i). Bu yuzden kota sayacina tick basina `1` degil, o tick'te
+    cekilen TICKER SAYISI islenir; aksi halde `market_api_usage` gercegin
+    ~16'da birini gosterir ve `MARKET_API_DAILY_QUOTA` tavani hic tetiklenmez.
 
     YEDEGE DUSME (fail-safe): Asagidaki durumlarda simulatore dusulur ve bu
     GIZLENMEZ - `son_kaynak` "simulated" olur, boylece `price_history`'ye
@@ -136,14 +138,27 @@ class ApiMarketProvider(MarketDataProvider):
             return True
         return False
 
-    async def _kotayi_isle(self, cagri: int = 1) -> None:
-        """Cagriyi `market_api_usage` tablosuna islenir. Hata yutulur."""
+    async def _kotayi_isle(self, cagri: int) -> None:
+        """Yapilan HTTP istegi sayisini `market_api_usage`'a isler. Hata yutulur.
+
+        `cagri` her zaman GERCEK ticker sayisidir; varsayilani bilincli olarak
+        yoktur ki yanlislikla tekrar `1` islenmesin.
+        """
         try:
             await self._depo().record_api_usage(cagri)
         except Exception:  # noqa: BLE001 - denetim kaydi asil isi dusurmemeli
             logger.exception("api kullanim sayaci yazilamadi")
 
     async def _yedege_dus(self, assets: list[dict]) -> list[dict]:
+        """Simulatore duser - TUM varliklar icin fiyat uretir.
+
+        BILINCLI FARK: basarili yolda yalnizca Yahoo'da karsiligi olan
+        varliklar guncellenir, burada ise hepsi. Yahoo eslemesi olmayan bir
+        varlik (orn. tahvil) aksi halde api modunda SONSUZA KADAR ayni fiyatta
+        donar ve grafigi duz cizgi olur. Uretilen fiyat "gercek" gibi
+        gosterilmez: `son_kaynak` "simulated" olur ve `price_history.source`
+        oyle yazilir.
+        """
         self.son_kaynak = self._fallback.name
         return await self._fallback.next_prices(assets)
 
@@ -161,17 +176,23 @@ class ApiMarketProvider(MarketDataProvider):
             logger.warning("yahoo'da karsiligi olan varlik yok, simulatore dusuluyor")
             return await self._yedege_dus(assets)
 
+        semboller = [a["symbol"] for a in istenen]
+
+        # Yahoo'ya atilacak GERCEK istek sayisi: her ticker ayri bir HTTP
+        # istegidir. Hata durumunda da islenir - istekler zaten yapilmistir.
+        cagri_sayisi = len(yahoo.gerekli_tickerlar(semboller))
+
         try:
-            fiyatlar = await yahoo.canli_fiyatlar([a["symbol"] for a in istenen])
+            fiyatlar = await yahoo.canli_fiyatlar(semboller)
         except Exception as exc:  # noqa: BLE001 - ag hatasi gorevi durdurmamali
             logger.warning(
                 "yahoo canli fiyat alinamadi, simulatore dusuluyor",
                 extra={"hata": f"{type(exc).__name__}: {exc}"},
             )
-            await self._kotayi_isle()
+            await self._kotayi_isle(cagri_sayisi)
             return await self._yedege_dus(assets)
 
-        await self._kotayi_isle()
+        await self._kotayi_isle(cagri_sayisi)
 
         if not fiyatlar:
             logger.warning("yahoo bos sonuc dondurdu, simulatore dusuluyor")

--- a/backend/app/market/provider.py
+++ b/backend/app/market/provider.py
@@ -72,30 +72,117 @@ class SimulatedMarketProvider(MarketDataProvider):
 
 
 class ApiMarketProvider(MarketDataProvider):
-    """Gercek piyasa API'si - HENUZ BAGLANMADI.
+    """Gercek piyasa verisi - Yahoo Finance (`app/market/yahoo.py`).
 
-    ⚠️ Gercek saglayici kullanimi PO onayi ve lisans kontrolu gerektirir
-    (mimari v4 bolum 8.3). Saglayici secildiginde YALNIZCA bu sinif yazilir;
-    scheduler, tool'lar ve dashboard degismez.
+    TEK ISTEK: Tum semboller `yf.download` ile TEK cagrida gelir. 15 dakikalik
+    tick ile gunde ~96 cagri eder; sembol basina ayri istek atilsaydi ~1.500
+    cagri olurdu ve yfinance resmi API olmadigi icin engellenme riski dogardi.
 
-    Uygulanirken ZORUNLU olanlar:
-      * Gunluk cagri sayaci (`market_api_usage` tablosu) - kota asilirsa
-        simulatore dus.
-      * Timeout ve hata durumunda simulatore dusme (demo gunu kesinti olmasin).
-      * Cekilen gercek fiyatin baz fiyat olarak yazilmasi (capa).
+    YEDEGE DUSME (fail-safe): Asagidaki durumlarda simulatore dusulur ve bu
+    GIZLENMEZ - `son_kaynak` "simulated" olur, boylece `price_history`'ye
+    yanlislikla "api" etiketi yazilmaz:
+      * Gunluk kota (`MARKET_API_DAILY_QUOTA`) dolduysa,
+      * Yahoo zaman asimina ugrar veya hata verirse,
+      * Hicbir sembol icin fiyat donmezse.
+
+    Yahoo'nun dondugu fiyatlar `assets.current_price` uzerine yazilir; yani
+    gercek fiyat ayni zamanda BAZ fiyattir (mimari v4 bolum 8.2 "capa").
     """
 
     name = "api"
 
-    def __init__(self, fallback: MarketDataProvider | None = None) -> None:
+    def __init__(
+        self,
+        fallback: MarketDataProvider | None = None,
+        kota_deposu=None,
+    ) -> None:
+        """
+        Args:
+            fallback: Yahoo kullanilamadiginda devreye giren saglayici.
+            kota_deposu: `get_api_usage_today` / `record_api_usage` sunan
+                depo. `None` ise calisma aninda `get_market_repository()`
+                kullanilir (testte enjekte edilebilsin diye parametre var).
+        """
         self._fallback = fallback or SimulatedMarketProvider()
+        self._kota_deposu = kota_deposu
+        #: Son `next_prices` cagrisinda GERCEKTEN kullanilan kaynak.
+        #: `price_history.source` bu degerden yazilir.
+        self.son_kaynak: str = self.name
+
+    def _depo(self):
+        if self._kota_deposu is not None:
+            return self._kota_deposu
+        from app.repositories.deps import get_market_repository
+
+        return get_market_repository()
+
+    async def _kota_doldu_mu(self) -> bool:
+        """Gunluk cagri tavani asildi mi? Sayac okunamazsa AKIS DURMAZ."""
+        tavan = settings.market_api_daily_quota
+        if tavan <= 0:
+            return False
+
+        try:
+            kullanilan = await self._depo().get_api_usage_today()
+        except Exception:  # noqa: BLE001 - sayac hatasi fiyat cekmeyi engellemesin
+            logger.exception("api kota sayaci okunamadi, cagri yine de denenecek")
+            return False
+
+        if kullanilan >= tavan:
+            logger.warning(
+                "gunluk api kotasi doldu, simulatore dusuluyor",
+                extra={"kullanilan": kullanilan, "tavan": tavan},
+            )
+            return True
+        return False
+
+    async def _kotayi_isle(self, cagri: int = 1) -> None:
+        """Cagriyi `market_api_usage` tablosuna islenir. Hata yutulur."""
+        try:
+            await self._depo().record_api_usage(cagri)
+        except Exception:  # noqa: BLE001 - denetim kaydi asil isi dusurmemeli
+            logger.exception("api kullanim sayaci yazilamadi")
+
+    async def _yedege_dus(self, assets: list[dict]) -> list[dict]:
+        self.son_kaynak = self._fallback.name
+        return await self._fallback.next_prices(assets)
 
     async def next_prices(self, assets: list[dict]) -> list[dict]:
-        logger.warning(
-            "gercek piyasa API saglayicisi baglanmadi, simulatore dusuldu",
-            extra={"provider": settings.market_data_provider},
-        )
-        return await self._fallback.next_prices(assets)
+        from app.market import yahoo
+
+        self.son_kaynak = self.name
+
+        if await self._kota_doldu_mu():
+            return await self._yedege_dus(assets)
+
+        # Yahoo'da karsiligi olmayan varliklar (orn. tahvil) hic istenmez.
+        istenen = [a for a in assets if a.get("symbol") in yahoo.desteklenen_semboller()]
+        if not istenen:
+            logger.warning("yahoo'da karsiligi olan varlik yok, simulatore dusuluyor")
+            return await self._yedege_dus(assets)
+
+        try:
+            fiyatlar = await yahoo.canli_fiyatlar([a["symbol"] for a in istenen])
+        except Exception as exc:  # noqa: BLE001 - ag hatasi gorevi durdurmamali
+            logger.warning(
+                "yahoo canli fiyat alinamadi, simulatore dusuluyor",
+                extra={"hata": f"{type(exc).__name__}: {exc}"},
+            )
+            await self._kotayi_isle()
+            return await self._yedege_dus(assets)
+
+        await self._kotayi_isle()
+
+        if not fiyatlar:
+            logger.warning("yahoo bos sonuc dondurdu, simulatore dusuluyor")
+            return await self._yedege_dus(assets)
+
+        # Fiyati alinamayan varlik listeye EKLENMEZ; eski fiyati korunur.
+        return [
+            {"asset_id": a["asset_id"], "price": fiyatlar[a["symbol"]]}
+            for a in istenen
+            if a["symbol"] in fiyatlar
+        ]
 
 
 def build_provider(name: str | None = None) -> MarketDataProvider:

--- a/backend/app/market/scheduler.py
+++ b/backend/app/market/scheduler.py
@@ -28,7 +28,12 @@ async def price_tick(provider: MarketDataProvider, write_history: bool) -> int:
         return 0
 
     updates = await provider.next_prices(assets)
-    return await repository.apply_price_updates(updates, write_history=write_history)
+
+    # Saglayici yedege dusmus olabilir (kota/ag hatasi); bu durumda kaynak
+    # "api" DEGIL "simulated"dir. `son_kaynak` yoksa saglayici adi kullanilir.
+    kaynak = getattr(provider, "son_kaynak", provider.name)
+
+    return await repository.apply_price_updates(updates, write_history=write_history, source=kaynak)
 
 
 async def run_price_scheduler(provider: MarketDataProvider | None = None) -> None:

--- a/backend/app/market/yahoo.py
+++ b/backend/app/market/yahoo.py
@@ -1,0 +1,196 @@
+"""Yahoo Finance canli fiyat istemcisi (mimari v4 bolum 8).
+
+Bu modul YALNIZCA fiyat ceker; veritabanini, zamanlayiciyi ve `assets`
+tablosunu BILMEZ. Yazma isi `ApiMarketProvider` -> `MarketRepository`
+zincirindedir.
+
+TEK ISTEK, TUM SEMBOLLER
+    Her varlik icin ayri istek atmak 16 cagri/tick eder; 15 dakikada bir
+    calisan gorev icin gunde ~1.500 cagri demektir ve yfinance resmi bir API
+    olmadigi icin bu hacim gecici engellemeye yol acar. Bunun yerine
+    `yf.download` TEK istekte tum sembolleri getirir: gunde ~96 cagri.
+
+BLOKLAMA
+    yfinance SENKRON bir kutuphanedir. Dogrudan cagrilirsa `asyncio` olay
+    dongusunu (event loop) bloklar ve tum API istekleri fiyat cekilirken
+    donar. Bu yuzden cagri `asyncio.to_thread` ile ayri bir is parcacigina
+    tasinir.
+
+TURETILMIS FIYATLAR
+    Yahoo'da "TRY cinsinden gram altin" diye bir sembol YOKTUR:
+
+        gram_TRY = (ons_USD / 31.1034768) * USDTRY
+
+    Bu saf maden degeridir; kuyumcu isciligi ve makasi ICERMEZ.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: 1 troy ons = 31.1034768 gram (kiymetli maden standardi).
+TROY_ONS_GRAM = 31.1034768
+
+#: Altin/gumus turetmesi icin gereken kur sembolu.
+USDTRY_TICKER = "USDTRY=X"
+
+#: `assets.symbol` -> Yahoo ticker. TEK DOGRULUK KAYNAGI.
+#:
+#: `borsa-verisi/` gecmis veri betigi de bu tabloyu kullanir; iki yerde
+#: tutulursa biri duzeltildiginde digeri sessizce bozulur.
+YAHOO_TICKERS: dict[str, str] = {
+    # BIST hisseleri - Yahoo'da ".IS" eki ile
+    "THYAO": "THYAO.IS",
+    "GARAN": "GARAN.IS",
+    "TCELL": "TCELL.IS",
+    "SASA": "SASA.IS",
+    "ASELS": "ASELS.IS",
+    "EREGL": "EREGL.IS",
+    # Doviz - "=X" eki ile
+    "USD/TRY": USDTRY_TICKER,
+    "EUR/TRY": "EURTRY=X",
+    # ABD hisseleri - dogrudan
+    "AAPL": "AAPL",
+    "TSLA": "TSLA",
+    "NVDA": "NVDA",
+    # Kripto - USD cinsinden
+    "BTC": "BTC-USD",
+    "ETH": "ETH-USD",
+    "SOL": "SOL-USD",
+}
+
+#: Dogrudan cekilemeyen, ons/USD fiyatindan gram/TRY'ye cevrilen varliklar.
+#: `assets.symbol` -> kaynak Yahoo ticker (vadeli sozlesme).
+TURETILMIS_GRAM_TRY: dict[str, str] = {
+    "GRAM_ALTIN": "GC=F",  # COMEX altin vadeli
+    "GUMUS": "SI=F",  # COMEX gumus vadeli
+}
+
+#: Yahoo cagrisi icin ust sinir. Ag takilirsa fiyat gorevi sonsuza kadar
+#: beklememelidir; saglayici bu surenin sonunda yedege duser.
+ISTEK_TIMEOUT_SANIYE = 30
+
+
+def desteklenen_semboller() -> set[str]:
+    """Yahoo'dan fiyati alinabilen tum `assets.symbol` degerleri."""
+    return set(YAHOO_TICKERS) | set(TURETILMIS_GRAM_TRY)
+
+
+def gerekli_tickerlar(db_symbols: list[str]) -> list[str]:
+    """Istenen semboller icin cekilmesi gereken Yahoo ticker listesi.
+
+    Turetilmis bir varlik istendiginde kaynak sozlesmenin YANI SIRA USD/TRY
+    kuru da gerekir; liste bunu otomatik ekler.
+    """
+    tickerlar: set[str] = set()
+    turetme_var = False
+
+    for sembol in db_symbols:
+        if sembol in YAHOO_TICKERS:
+            tickerlar.add(YAHOO_TICKERS[sembol])
+        elif sembol in TURETILMIS_GRAM_TRY:
+            tickerlar.add(TURETILMIS_GRAM_TRY[sembol])
+            turetme_var = True
+
+    if turetme_var:
+        tickerlar.add(USDTRY_TICKER)
+
+    return sorted(tickerlar)
+
+
+def _son_fiyatlar(df: Any, tickerlar: list[str]) -> dict[str, float]:
+    """`yf.download` ciktisindan ticker -> son gecerli kapanis sozlugu uretir.
+
+    yfinance tek ticker'da duz, coklu ticker'da MultiIndex kolon dondurur;
+    iki bicim de burada normalize edilir.
+    """
+    if df is None or len(df) == 0:
+        return {}
+
+    kapanis = df["Close"]
+    # Tek ticker istendiginde `Close` bir Series'tir.
+    if hasattr(kapanis, "to_frame") and getattr(kapanis, "ndim", 2) == 1:
+        kapanis = kapanis.to_frame(name=tickerlar[0])
+
+    sonuc: dict[str, float] = {}
+    for ticker in kapanis.columns:
+        seri = kapanis[ticker].dropna()
+        if seri.empty:
+            continue
+        fiyat = float(seri.iloc[-1])
+        if fiyat > 0:
+            sonuc[str(ticker)] = fiyat
+
+    return sonuc
+
+
+def _indir(tickerlar: list[str]) -> dict[str, float]:
+    """SENKRON indirme - `asyncio.to_thread` icinden cagrilir."""
+    import yfinance as yf
+
+    df = yf.download(
+        " ".join(tickerlar),
+        period="1d",
+        interval="1m",
+        progress=False,
+        auto_adjust=False,
+        threads=True,
+    )
+    return _son_fiyatlar(df, tickerlar)
+
+
+def fiyatlari_turet(ham: dict[str, float], db_symbols: list[str]) -> dict[str, float]:
+    """Yahoo ticker fiyatlarini `assets.symbol` fiyatlarina cevirir.
+
+    Turetilmis varliklar (gram altin/gumus) burada hesaplanir. Kur yoksa o
+    varlik sonuca EKLENMEZ - yanlis fiyat yazmaktansa eski fiyat korunur.
+    """
+    usdtry = ham.get(USDTRY_TICKER)
+    sonuc: dict[str, float] = {}
+
+    for sembol in db_symbols:
+        if sembol in YAHOO_TICKERS:
+            fiyat = ham.get(YAHOO_TICKERS[sembol])
+            if fiyat:
+                sonuc[sembol] = round(fiyat, 4)
+            continue
+
+        if sembol in TURETILMIS_GRAM_TRY:
+            ons_usd = ham.get(TURETILMIS_GRAM_TRY[sembol])
+            if not ons_usd or not usdtry:
+                logger.warning(
+                    "turetilmis fiyat hesaplanamadi (kur veya ons fiyati yok)",
+                    extra={"sembol": sembol},
+                )
+                continue
+            sonuc[sembol] = round((ons_usd / TROY_ONS_GRAM) * usdtry, 4)
+
+    return sonuc
+
+
+async def canli_fiyatlar(db_symbols: list[str]) -> dict[str, float]:
+    """Verilen `assets.symbol` listesi icin guncel fiyatlari doner.
+
+    Returns:
+        `{sembol: fiyat}`. Fiyati alinamayan sembol sozlukte YER ALMAZ;
+        cagiran taraf eski fiyati korur.
+
+    Raises:
+        TimeoutError: Yahoo `ISTEK_TIMEOUT_SANIYE` icinde yanit vermezse.
+    """
+    tickerlar = gerekli_tickerlar(db_symbols)
+    if not tickerlar:
+        return {}
+
+    ham = await asyncio.wait_for(asyncio.to_thread(_indir, tickerlar), timeout=ISTEK_TIMEOUT_SANIYE)
+
+    fiyatlar = fiyatlari_turet(ham, db_symbols)
+    logger.info(
+        "yahoo canli fiyat alindi",
+        extra={"istenen": len(db_symbols), "alinan": len(fiyatlar), "cagri": 1},
+    )
+    return fiyatlar

--- a/backend/app/market/yahoo.py
+++ b/backend/app/market/yahoo.py
@@ -4,11 +4,19 @@ Bu modul YALNIZCA fiyat ceker; veritabanini, zamanlayiciyi ve `assets`
 tablosunu BILMEZ. Yazma isi `ApiMarketProvider` -> `MarketRepository`
 zincirindedir.
 
-TEK ISTEK, TUM SEMBOLLER
-    Her varlik icin ayri istek atmak 16 cagri/tick eder; 15 dakikada bir
-    calisan gorev icin gunde ~1.500 cagri demektir ve yfinance resmi bir API
-    olmadigi icin bu hacim gecici engellemeye yol acar. Bunun yerine
-    `yf.download` TEK istekte tum sembolleri getirir: gunde ~96 cagri.
+CAGRI SAYISI: SEMBOL BASINA BIR ISTEK
+    `yf.download` disaridan TEK bir cagri gibi gorunur ama iceride ticker
+    listesi uzerinde DONER ve her ticker icin ayri bir HTTP istegi atar
+    (yfinance/multi.py: `_download_one` -> `Ticker.history`). `threads=True`
+    bu istekleri yalnizca PARALELLESTIRIR, tek istege indirmez.
+
+    Yani N sembol = N istek. Bu modulun sembol listesi 16 ticker uretir;
+    15 dakikalik tick ile gunde ~1.536 istek eder. Kota sayaci bu yuzden
+    tick basina 1 degil GERCEK ticker sayisi kadar islenmelidir - bkz.
+    `ApiMarketProvider.next_prices`.
+
+    Hacmi dusurmenin yolu tick araligini buyutmek veya sembol listesini
+    kisaltmaktir; tek istege indirmek yfinance ile MUMKUN DEGILDIR.
 
 BLOKLAMA
     yfinance SENKRON bir kutuphanedir. Dogrudan cagrilirsa `asyncio` olay
@@ -38,10 +46,12 @@ TROY_ONS_GRAM = 31.1034768
 #: Altin/gumus turetmesi icin gereken kur sembolu.
 USDTRY_TICKER = "USDTRY=X"
 
-#: `assets.symbol` -> Yahoo ticker. TEK DOGRULUK KAYNAGI.
+#: `assets.symbol` -> Yahoo ticker.
 #:
-#: `borsa-verisi/` gecmis veri betigi de bu tabloyu kullanir; iki yerde
-#: tutulursa biri duzeltildiginde digeri sessizce bozulur.
+#: AYNI ESLEME IKI YERDE DURUR: `borsa-verisi/symbols.py` bagimsiz bir
+#: betiktir, backend'i import ETMEZ ve tabloyu kendi bicimiyle tutar. Elle
+#: senkron tutulurlar; ayrisirlarsa `tests/test_yahoo_client.py` icindeki
+#: senkron testi CI'da hata verir - yani sessizce bozulamazlar.
 YAHOO_TICKERS: dict[str, str] = {
     # BIST hisseleri - Yahoo'da ".IS" eki ile
     "THYAO": "THYAO.IS",
@@ -70,9 +80,18 @@ TURETILMIS_GRAM_TRY: dict[str, str] = {
     "GUMUS": "SI=F",  # COMEX gumus vadeli
 }
 
-#: Yahoo cagrisi icin ust sinir. Ag takilirsa fiyat gorevi sonsuza kadar
+#: Yahoo cagrisi icin DIS ust sinir. Ag takilirsa fiyat gorevi sonsuza kadar
 #: beklememelidir; saglayici bu surenin sonunda yedege duser.
 ISTEK_TIMEOUT_SANIYE = 30
+
+#: yfinance'e GECIRILEN istek basina timeout.
+#:
+#: NEDEN AYRICA GEREKLI: `asyncio.wait_for` bir is parcacigini IPTAL EDEMEZ.
+#: Dis sure dolunca `to_thread` icindeki indirme calismaya DEVAM eder ve
+#: yfinance kendi ic is parcaciklarini da actigi icin takilan cagrilar tick
+#: tick birikir. Asil sinir bu yuzden ICERIDE olmali; dis sinir son caredir.
+#: yfinance'in varsayilani 10 sn'dir, burada acikca verilir.
+YFINANCE_TIMEOUT_SANIYE = 12
 
 
 def desteklenen_semboller() -> set[str]:
@@ -139,6 +158,7 @@ def _indir(tickerlar: list[str]) -> dict[str, float]:
         progress=False,
         auto_adjust=False,
         threads=True,
+        timeout=YFINANCE_TIMEOUT_SANIYE,
     )
     return _son_fiyatlar(df, tickerlar)
 
@@ -175,6 +195,9 @@ def fiyatlari_turet(ham: dict[str, float], db_symbols: list[str]) -> dict[str, f
 async def canli_fiyatlar(db_symbols: list[str]) -> dict[str, float]:
     """Verilen `assets.symbol` listesi icin guncel fiyatlari doner.
 
+    Bir cagrida kac HTTP istegi atildigini cagiran taraf `gerekli_tickerlar()`
+    ile ogrenir (her ticker = bir istek; bkz. modul docstring'i).
+
     Returns:
         `{sembol: fiyat}`. Fiyati alinamayan sembol sozlukte YER ALMAZ;
         cagiran taraf eski fiyati korur.
@@ -191,6 +214,11 @@ async def canli_fiyatlar(db_symbols: list[str]) -> dict[str, float]:
     fiyatlar = fiyatlari_turet(ham, db_symbols)
     logger.info(
         "yahoo canli fiyat alindi",
-        extra={"istenen": len(db_symbols), "alinan": len(fiyatlar), "cagri": 1},
+        extra={
+            "istenen": len(db_symbols),
+            "alinan": len(fiyatlar),
+            # Her ticker ayri bir HTTP istegidir - "1" DEGIL.
+            "cagri": len(tickerlar),
+        },
     )
     return fiyatlar

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -68,8 +68,24 @@ class MarketRepository(Protocol):
         """Fiyat gorevinin ihtiyaci: id, symbol, current_price, sim_volatility."""
         ...
 
-    async def apply_price_updates(self, updates: list[dict], write_history: bool) -> int:
-        """Uretilen fiyatlari yazar. `updates`: `{asset_id, price}` kayitlari."""
+    async def apply_price_updates(
+        self, updates: list[dict], write_history: bool, source: str = "simulated"
+    ) -> int:
+        """Uretilen fiyatlari yazar. `updates`: `{asset_id, price}` kayitlari.
+
+        `source` `price_history.source` sutununa yazilir ve GERCEKTEN
+        kullanilan kaynagi belirtmelidir ("api" | "simulated"). Gercek veri
+        "simulated" etiketlenirse ileride hangi satirin guvenilir oldugu
+        ayirt edilemez.
+        """
+        ...
+
+    async def get_api_usage_today(self) -> int:
+        """Bugun dis piyasa API'sine kac cagri yapildi (kota korumasi)."""
+        ...
+
+    async def record_api_usage(self, calls: int = 1) -> None:
+        """Gunluk cagri sayacini artirir (`market_api_usage`)."""
         ...
 
 

--- a/backend/app/repositories/in_memory.py
+++ b/backend/app/repositories/in_memory.py
@@ -499,7 +499,9 @@ class InMemoryMarketRepository:
             for a in _ASSETS
         ]
 
-    async def apply_price_updates(self, updates: list[dict], write_history: bool) -> int:
+    async def apply_price_updates(
+        self, updates: list[dict], write_history: bool, source: str = "simulated"
+    ) -> int:
         for update in updates:
             asset = next((a for a in _ASSETS if a["id"] == update["asset_id"]), None)
             if asset is None:
@@ -510,6 +512,17 @@ class InMemoryMarketRepository:
             if previous:
                 asset["daily_change_pct"] = round((new_price - previous) / previous * 100, 4)
         return len(updates)
+
+    async def get_api_usage_today(self) -> int:
+        """Yedek katmanda kota takibi YOKTUR; her zaman 0 doner.
+
+        Bellek ici mod bir gelistirme/demo yedegidir ve dis API cagrisi
+        yapilmayabilir; sayaci burada tutmak yaniltici olurdu.
+        """
+        return 0
+
+    async def record_api_usage(self, calls: int = 1) -> None:
+        return None
 
 
 class InMemoryRagRepository:

--- a/backend/app/repositories/in_memory.py
+++ b/backend/app/repositories/in_memory.py
@@ -161,16 +161,23 @@ _SEED_ASSETS: list[dict] = [
 #: Calisma zamaninda GUNCELLENEN kopya (fiyat gorevi buraya yazar).
 _ASSETS: list[dict] = [dict(a) for a in _SEED_ASSETS]
 
+#: `market_api_usage` tablosunun bellek ici karsiligi: ISO tarih -> istek
+#: sayisi. `market_api_usage` gibi kalici DEGILDIR, surec yeniden baslayinca
+#: sifirlanir; amaci DB'siz calisirken gunluk tavanin yok olmasini onlemektir.
+_API_USAGE: dict[str, int] = {}
+
 
 def reset_data() -> None:
-    """Varlik fiyatlarini tohum degerlerine dondurur.
+    """Varlik fiyatlarini ve api sayacini tohum degerlerine dondurur.
 
-    Fiyat gorevi bellek ici veriyi yerinde gunceller; testler bu yuzden
-    birbirinin fiyatlarini gorur. `tests/conftest.py` her testten once bunu
-    cagirir. Uretimde cagrilmaz.
+    Fiyat gorevi bellek ici veriyi YERINDE gunceller, yani durum surec omru
+    boyunca birikir; birbirinden bagimsiz olmasi gereken testler bunu acikca
+    cagirmalidir. `conftest.py` artik otomatik cagirmiyor (testler gercek
+    PostgreSQL'e tasindi). Uretimde cagrilmaz.
     """
     _ASSETS.clear()
     _ASSETS.extend(dict(a) for a in _SEED_ASSETS)
+    _API_USAGE.clear()
 
 
 _PORTFOLIOS: list[dict] = [
@@ -285,6 +292,11 @@ _RAG_CHUNKS: list[dict] = [
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _bugun() -> str:
+    """Api sayacinin gun anahtari - SQL'deki `CURRENT_DATE` karsiligi."""
+    return _now().date().isoformat()
 
 
 def _asset(asset_id: int) -> dict:
@@ -514,15 +526,24 @@ class InMemoryMarketRepository:
         return len(updates)
 
     async def get_api_usage_today(self) -> int:
-        """Yedek katmanda kota takibi YOKTUR; her zaman 0 doner.
+        """Bugun dis piyasa API'sine yapilan ISTEK sayisi.
 
-        Bellek ici mod bir gelistirme/demo yedegidir ve dis API cagrisi
-        yapilmayabilir; sayaci burada tutmak yaniltici olurdu.
+        BELLEK ICI MODDA DA GERCEKTEN SAYILIR. Daha once burasi sabit `0`
+        donuyordu; DB'ye ulasilamadiginda repository katmani bu yedege duser
+        ama `MARKET_DATA_PROVIDER=api` ise Yahoo cagrilari DEVAM eder - yani
+        tam da kotanin en cok gerektigi anda tavan tamamen ortadan kalkiyordu.
+
+        Sayac kalici degildir: surec yeniden baslayinca sifirlanir. DB'li
+        moddaki `market_api_usage` tablosunun yerini TUTMAZ, yalnizca yedek
+        moddaki sinirsizligi kapatir.
         """
-        return 0
+        return _API_USAGE.get(_bugun(), 0)
 
     async def record_api_usage(self, calls: int = 1) -> None:
-        return None
+        if calls <= 0:
+            return
+        bugun = _bugun()
+        _API_USAGE[bugun] = _API_USAGE.get(bugun, 0) + calls
 
 
 class InMemoryRagRepository:

--- a/backend/app/repositories/sql.py
+++ b/backend/app/repositories/sql.py
@@ -203,12 +203,18 @@ class SqlMarketRepository(_SqlRepository):
             """
         )
 
-    async def apply_price_updates(self, updates: list[dict], write_history: bool) -> int:
+    async def apply_price_updates(
+        self, updates: list[dict], write_history: bool, source: str = "simulated"
+    ) -> int:
         """Fiyatlari gunceller; istenirse `price_history`'ye de yazar.
 
         `daily_change_pct` ve `weekly_change_pct` YENIDEN HESAPLANIR - aksi
         halde seed degerinde donar ve dashboard hep ayni yuzdeyi gosterir
         (mimari v4 bolum 8.2).
+
+        `source` cagiran tarafindan verilir ve GERCEKTEN kullanilan kaynagi
+        belirtir: saglayici Yahoo'ya ulasamayip simulatore dustuyse "api"
+        DEGIL "simulated" yazilir (bkz. `ApiMarketProvider.son_kaynak`).
         """
         if not updates:
             return 0
@@ -240,12 +246,12 @@ class SqlMarketRepository(_SqlRepository):
                         """
                         INSERT INTO price_history (asset_id, ts, price, source)
                         SELECT (value->>'asset_id')::INT, date_trunc('second', now()),
-                               (value->>'price')::NUMERIC, 'simulated'
+                               (value->>'price')::NUMERIC, :source
                         FROM jsonb_array_elements(CAST(:payload AS JSONB))
                         ON CONFLICT (asset_id, ts) DO NOTHING
                         """
                     ),
-                    {"payload": _json(updates)},
+                    {"payload": _json(updates), "source": source},
                 )
 
             await session.execute(
@@ -267,6 +273,39 @@ class SqlMarketRepository(_SqlRepository):
             await session.commit()
 
         return len(updates)
+
+    async def get_api_usage_today(self) -> int:
+        """Bugun dis piyasa API'sine yapilan cagri sayisi."""
+        async with self._session_factory() as session:
+            sonuc = await session.execute(
+                text("SELECT call_count FROM market_api_usage WHERE usage_date = CURRENT_DATE")
+            )
+            satir = sonuc.first()
+            return int(satir[0]) if satir else 0
+
+    async def record_api_usage(self, calls: int = 1) -> None:
+        """Gunluk cagri sayacini artirir.
+
+        UPSERT: gunun ilk cagrisinda satir yaratilir, sonrakiler UZERINE
+        EKLENIR (sifirlanmaz).
+        """
+        if calls <= 0:
+            return
+
+        async with self._session_factory() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO market_api_usage (usage_date, call_count, last_call_at)
+                    VALUES (CURRENT_DATE, :calls, now())
+                    ON CONFLICT (usage_date) DO UPDATE
+                        SET call_count   = market_api_usage.call_count + EXCLUDED.call_count,
+                            last_call_at = now()
+                    """
+                ),
+                {"calls": calls},
+            )
+            await session.commit()
 
 
 class SqlRagRepository(_SqlRepository):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,7 +34,10 @@ yfinance==1.3.0
 # DataFrame kolon yapisina (tek ticker'da duz, coklu ticker'da MultiIndex)
 # dogrudan bagimlidir ve testleri pandas'i acikca import eder. Sabitlenmezse
 # backend ile borsa-verisi/ farkli pandas surumlerine dusebilir.
-pandas==2.2.1
+# 2.2.1 DEGIL: o surumun Python 3.13 icin hazir paketi (wheel) yok, pip
+# kaynaktan derlemeye calisir ve derleme hatasiyla duser. 2.2.3 ayni 2.2
+# serisinde ve cp313 wheel'i var.
+pandas==2.2.3
 
 # Kimlik dogrulama (app/auth/) - Python 3.13'te crypt modulu kaldirildigi icin
 # passlib yerine dogrudan bcrypt (docs/backend-kararlar.md bolum 1).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,11 @@ google-genai==1.75.0
 sqlalchemy[asyncio]==2.0.36
 psycopg[binary]==3.2.3
 
+# Canli piyasa verisi (app/market/yahoo.py). Resmi bir API DEGILDIR: Yahoo'nun
+# genel uclarini kullanir, sembol adlari ve veri surekliligi garanti degildir.
+# Ulasilamadiginda saglayici simulatore duser, sistem calismaya devam eder.
+yfinance==1.3.0
+
 # Kimlik dogrulama (app/auth/) - Python 3.13'te crypt modulu kaldirildigi icin
 # passlib yerine dogrudan bcrypt (docs/backend-kararlar.md bolum 1).
 PyJWT==2.10.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,7 +27,14 @@ psycopg[binary]==3.2.3
 # Canli piyasa verisi (app/market/yahoo.py). Resmi bir API DEGILDIR: Yahoo'nun
 # genel uclarini kullanir, sembol adlari ve veri surekliligi garanti degildir.
 # Ulasilamadiginda saglayici simulatore duser, sistem calismaya devam eder.
+# borsa-verisi/requirements.txt ile AYNI surum tutulur.
 yfinance==1.3.0
+
+# yfinance zaten getirir ama SURUMU SABITLENIR: `_son_fiyatlar` yfinance'in
+# DataFrame kolon yapisina (tek ticker'da duz, coklu ticker'da MultiIndex)
+# dogrudan bagimlidir ve testleri pandas'i acikca import eder. Sabitlenmezse
+# backend ile borsa-verisi/ farkli pandas surumlerine dusebilir.
+pandas==2.2.1
 
 # Kimlik dogrulama (app/auth/) - Python 3.13'te crypt modulu kaldirildigi icin
 # passlib yerine dogrudan bcrypt (docs/backend-kararlar.md bolum 1).

--- a/backend/run.py
+++ b/backend/run.py
@@ -30,4 +30,8 @@ if sys.platform == "win32":
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True, reload_dirs=["app"])
+    # 127.0.0.1 - bu betik YEREL gelistirme icindir. "0.0.0.0" sunucuyu ayni
+    # agdaki herkese acar; kafe/okul agindayken JWT_SECRET varsayilaniyla
+    # calisan bir API disariya acik olur. Docker/production'da adres
+    # Dockerfile'daki CMD ile verilir, bu dosya oraya hic girmez.
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000, reload=True, reload_dirs=["app"])

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,33 @@
+"""Uygulamayi baslatir - Windows'ta `uvicorn app.main:app` YERINE bunu calistirin.
+
+    python run.py
+
+NEDEN GEREKLI (yalnizca Windows)
+    psycopg'nin async surucusu, Windows'un VARSAYILAN event loop'u olan
+    ProactorEventLoop ile calismaz. Duzeltme normalde
+    `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` ama bu
+    satir `app/main.py` icine konursa ISE YARAMAZ: `uvicorn app.main:app`
+    komutu once KENDI event loop'unu `asyncio.run()` ile olusturur, `app.main`
+    modulunu ise o loop'un ICINDE, gecikmeli import eder (Config.load()).
+    Yani policy o zaman ayarlansa bile loop ZATEN kurulmus olur.
+
+    Bu betik policy'yi uvicorn'un KENDI event loop'unu olusturmasindan
+    (`uvicorn.run()` cagrisindan) ONCE ayarlar - dogru sira budur.
+
+Linux/macOS'ta (CI, production, Docker) bu dosyaya GEREK YOKTUR;
+`uvicorn app.main:app` orada sorunsuz calisir ve Dockerfile'daki CMD
+degistirilmedi.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True, reload_dirs=["app"])

--- a/backend/tests/test_market_layer.py
+++ b/backend/tests/test_market_layer.py
@@ -49,23 +49,179 @@ async def test_simulator_sifir_fiyatli_varligi_atlar():
     assert sonuc == []
 
 
-async def test_api_saglayici_baglanmadigi_icin_simulatore_duser():
-    """Gercek API PO onayi bekliyor; sistem yine de calismali."""
-    sonuc = await ApiMarketProvider().next_prices(VARLIKLAR)
-
-    assert len(sonuc) == len(VARLIKLAR)
-
-
 @pytest.mark.parametrize(
     ("ayar", "beklenen"),
     [
         ("simulated", SimulatedMarketProvider),
         ("api", ApiMarketProvider),
-        ("", SimulatedMarketProvider),
     ],
 )
 def test_saglayici_ayara_gore_secilir(ayar, beklenen):
     assert isinstance(build_provider(ayar), beklenen)
+
+
+def test_ayar_bos_birakilirsa_varsayilan_saglayici_secilir(monkeypatch):
+    """Bos ayar `MARKET_DATA_PROVIDER` varsayilanina duser (su an "api")."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "market_data_provider", "api")
+    assert isinstance(build_provider(""), ApiMarketProvider)
+
+    monkeypatch.setattr(settings, "market_data_provider", "simulated")
+    assert isinstance(build_provider(""), SimulatedMarketProvider)
+
+
+# ---------------------------------------------------------------------------
+# ApiMarketProvider - Yahoo'ya baglanan gercek saglayici
+#
+# Bu testler AGA CIKMAZ: `app.market.yahoo.canli_fiyatlar` degistirilir.
+# Gercek cagri yapilsaydi testler yavas ve kirilgan olurdu (Yahoo resmi API
+# degildir; kesinti veya engelleme CI'yi kirmis olurdu).
+# ---------------------------------------------------------------------------
+
+
+class SahteKotaDeposu:
+    """`get_api_usage_today` / `record_api_usage` sunan bellek ici depo."""
+
+    def __init__(self, kullanilan: int = 0) -> None:
+        self.kullanilan = kullanilan
+        self.kaydedilen = 0
+
+    async def get_api_usage_today(self) -> int:
+        return self.kullanilan
+
+    async def record_api_usage(self, calls: int = 1) -> None:
+        self.kaydedilen += calls
+
+
+def _yahoo_taklit(monkeypatch, fiyatlar=None, hata: Exception | None = None):
+    """`canli_fiyatlar` yerine sahte bir uygulama koyar; cagriyi kaydeder."""
+    from app.market import yahoo
+
+    cagrilar: list[list[str]] = []
+
+    async def sahte(db_symbols):
+        cagrilar.append(list(db_symbols))
+        if hata is not None:
+            raise hata
+        return fiyatlar or {}
+
+    monkeypatch.setattr(yahoo, "canli_fiyatlar", sahte)
+    return cagrilar
+
+
+async def test_api_saglayici_yahoo_fiyatlarini_dondurur(monkeypatch):
+    _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25, "BTC": 64227.97})
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu())
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert sonuc == [
+        {"asset_id": 1, "price": 301.25},
+        {"asset_id": 12, "price": 64227.97},
+    ]
+    assert saglayici.son_kaynak == "api"
+
+
+async def test_fiyati_alinamayan_varlik_atlanir(monkeypatch):
+    """Eksik fiyat icin eski deger korunur; listeye EKLENMEZ."""
+    _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25})
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu())
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert sonuc == [{"asset_id": 1, "price": 301.25}]
+
+
+async def test_yahoo_hata_verirse_simulatore_dusulur(monkeypatch):
+    """KRITIK: ag hatasi fiyat gorevini durdurmamali."""
+    _yahoo_taklit(monkeypatch, hata=TimeoutError("yahoo yanit vermedi"))
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu())
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert len(sonuc) == len(VARLIKLAR)
+    assert saglayici.son_kaynak == "simulated"
+
+
+async def test_yahoo_bos_dondururse_simulatore_dusulur(monkeypatch):
+    _yahoo_taklit(monkeypatch, fiyatlar={})
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu())
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert len(sonuc) == len(VARLIKLAR)
+    assert saglayici.son_kaynak == "simulated"
+
+
+async def test_kota_dolduysa_yahoo_hic_cagrilmaz(monkeypatch):
+    """Kota korumasi: tavan asildiysa istek ATILMAZ, simulatore dusulur."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "market_api_daily_quota", 100)
+    cagrilar = _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 1.0})
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu(kullanilan=100))
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert cagrilar == [], "kota dolduysa Yahoo'ya istek atilmamali"
+    assert saglayici.son_kaynak == "simulated"
+    assert len(sonuc) == len(VARLIKLAR)
+
+
+async def test_basarili_cagri_kota_sayacina_islenir(monkeypatch):
+    _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25, "BTC": 64227.97})
+    depo = SahteKotaDeposu()
+
+    await ApiMarketProvider(kota_deposu=depo).next_prices(VARLIKLAR)
+
+    assert depo.kaydedilen == 1, "tum semboller TEK cagride gelir"
+
+
+async def test_desteklenmeyen_varlik_yahoo_ya_sorulmaz(monkeypatch):
+    """Yahoo'da karsiligi olmayan sembol (orn. tahvil) istege dahil edilmez."""
+    cagrilar = _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25})
+    varliklar = VARLIKLAR + [
+        {"asset_id": 99, "symbol": "TR10Y", "current_price": 100.0, "sim_volatility": 0.002}
+    ]
+
+    await ApiMarketProvider(kota_deposu=SahteKotaDeposu()).next_prices(varliklar)
+
+    assert "TR10Y" not in cagrilar[0]
+
+
+async def test_hicbir_varlik_desteklenmiyorsa_simulatore_dusulur(monkeypatch):
+    cagrilar = _yahoo_taklit(monkeypatch, fiyatlar={})
+    varliklar = [
+        {"asset_id": 99, "symbol": "TR10Y", "current_price": 100.0, "sim_volatility": 0.002}
+    ]
+
+    saglayici = ApiMarketProvider(kota_deposu=SahteKotaDeposu())
+    sonuc = await saglayici.next_prices(varliklar)
+
+    assert cagrilar == []
+    assert saglayici.son_kaynak == "simulated"
+    assert len(sonuc) == 1
+
+
+async def test_kota_sayaci_okunamazsa_cagri_yine_de_yapilir(monkeypatch):
+    """Sayac bir yan kayittir; okunamamasi fiyat cekmeyi engellememeli."""
+
+    class BozukDepo:
+        async def get_api_usage_today(self):
+            raise RuntimeError("tablo yok")
+
+        async def record_api_usage(self, calls=1):
+            raise RuntimeError("tablo yok")
+
+    cagrilar = _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25, "BTC": 64227.97})
+    saglayici = ApiMarketProvider(kota_deposu=BozukDepo())
+
+    sonuc = await saglayici.next_prices(VARLIKLAR)
+
+    assert cagrilar, "sayac hatasi cagriyi engellememeli"
+    assert saglayici.son_kaynak == "api"
+    assert len(sonuc) == 2
 
 
 @pytest.mark.db

--- a/backend/tests/test_market_layer.py
+++ b/backend/tests/test_market_layer.py
@@ -169,13 +169,42 @@ async def test_kota_dolduysa_yahoo_hic_cagrilmaz(monkeypatch):
     assert len(sonuc) == len(VARLIKLAR)
 
 
-async def test_basarili_cagri_kota_sayacina_islenir(monkeypatch):
+async def test_kota_sayacina_TICKER_SAYISI_islenir(monkeypatch):
+    """KRITIK: `yf.download` tek istek DEGILDIR - her ticker ayri HTTP istegi.
+
+    Sayac tick basina `1` islerse `market_api_usage` gercegin ~16'da birini
+    gosterir ve `MARKET_API_DAILY_QUOTA` tavani hicbir zaman tetiklenmez.
+    """
     _yahoo_taklit(monkeypatch, fiyatlar={"THYAO": 301.25, "BTC": 64227.97})
     depo = SahteKotaDeposu()
 
     await ApiMarketProvider(kota_deposu=depo).next_prices(VARLIKLAR)
 
-    assert depo.kaydedilen == 1, "tum semboller TEK cagride gelir"
+    # THYAO.IS + BTC-USD = 2 istek
+    assert depo.kaydedilen == 2
+
+
+async def test_turetilmis_varligin_kur_istegi_de_sayilir(monkeypatch):
+    """GRAM_ALTIN icin GC=F'nin YANI SIRA USDTRY=X de cekilir: 2 istek."""
+    _yahoo_taklit(monkeypatch, fiyatlar={"GRAM_ALTIN": 6864.63})
+    depo = SahteKotaDeposu()
+    varliklar = [
+        {"asset_id": 7, "symbol": "GRAM_ALTIN", "current_price": 6800.0, "sim_volatility": 0.008}
+    ]
+
+    await ApiMarketProvider(kota_deposu=depo).next_prices(varliklar)
+
+    assert depo.kaydedilen == 2
+
+
+async def test_hata_durumunda_da_gercek_istek_sayisi_islenir(monkeypatch):
+    """Istekler zaten yapildi; hata aldik diye kotadan dusulmemeleri olmaz."""
+    _yahoo_taklit(monkeypatch, hata=TimeoutError("yahoo yanit vermedi"))
+    depo = SahteKotaDeposu()
+
+    await ApiMarketProvider(kota_deposu=depo).next_prices(VARLIKLAR)
+
+    assert depo.kaydedilen == 2
 
 
 async def test_desteklenmeyen_varlik_yahoo_ya_sorulmaz(monkeypatch):
@@ -202,6 +231,30 @@ async def test_hicbir_varlik_desteklenmiyorsa_simulatore_dusulur(monkeypatch):
     assert cagrilar == []
     assert saglayici.son_kaynak == "simulated"
     assert len(sonuc) == 1
+
+
+async def test_bellek_ici_depo_kota_sayacini_gercekten_tutar():
+    """Yedek katmanda tavan YOK OLMAMALI.
+
+    DB'ye ulasilamadiginda repository katmani bellek ici yedege duser ama
+    `MARKET_DATA_PROVIDER=api` ise Yahoo cagrilari devam eder. Sayac burada
+    sabit `0` donerse gunluk tavan tam da en cok gerektigi anda devre disi
+    kalir - yani kota korumasi sessizce kaybolur.
+    """
+    from app.repositories.in_memory import InMemoryMarketRepository, reset_data
+
+    reset_data()
+    depo = InMemoryMarketRepository()
+
+    assert await depo.get_api_usage_today() == 0
+
+    await depo.record_api_usage(16)
+    await depo.record_api_usage(16)
+
+    assert await depo.get_api_usage_today() == 32
+
+    reset_data()
+    assert await depo.get_api_usage_today() == 0
 
 
 async def test_kota_sayaci_okunamazsa_cagri_yine_de_yapilir(monkeypatch):

--- a/backend/tests/test_yahoo_client.py
+++ b/backend/tests/test_yahoo_client.py
@@ -1,15 +1,23 @@
 """Yahoo canli fiyat istemcisinin saf mantigi (`app/market/yahoo.py`).
 
-BU TESTLER AGA CIKMAZ: yalnizca sembol eslemesi, ticker listesi uretimi ve
-gram/TRY turetmesi sinanir. Gercek indirme `_indir` icinde izole edilmistir.
+BU TESTLER AGA CIKMAZ: sembol eslemesi, ticker listesi uretimi, gram/TRY
+turetmesi ve `yf.download` ciktisinin cozulmesi sinanir. Gercek indirme
+`_indir` icinde izole edilmistir; DataFrame'ler elde kurulur.
 
 Kritik davranislar:
   * Turetilmis varlik istendiginde USD/TRY kuru OTOMATIK istege eklenir;
     eklenmezse gram altin fiyati hesaplanamaz.
   * Kur veya ons fiyati eksikse turetilmis varlik sonuca EKLENMEZ - yanlis
     fiyat yazmaktansa eski fiyat korunur.
+  * `_son_fiyatlar` yfinance'in IKI farkli kolon bicimini de cozer; bozulursa
+    sessizce bos sonuc doner ve sistem farkinda olmadan simulatore duser.
 """
 
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
 import pytest
 
 from app.market import yahoo
@@ -142,3 +150,144 @@ async def test_bos_sembol_listesi_ag_cagrisi_yapmaz():
 
 async def test_yalnizca_desteklenmeyen_sembollerde_cagri_yapilmaz():
     assert await yahoo.canli_fiyatlar(["TR10Y", "YOKBOYLE"]) == {}
+
+
+# ---------------------------------------------------------------------------
+# `yf.download` ciktisinin cozulmesi (`_son_fiyatlar`)
+#
+# BU MODULDEKI EN KIRILGAN YER: yfinance surum degisikliklerinde kolon yapisi
+# degisir. Bozuldugunda istisna FIRLATMAZ, sessizce bos sozluk doner - yani
+# saglayici "Yahoo bos dondu" deyip simulatore duser ve kimse fark etmez.
+# ---------------------------------------------------------------------------
+
+NAN = float("nan")
+
+
+def _coklu_ticker_df(kapanislar: dict[str, list[float]]) -> pd.DataFrame:
+    """`yf.download`'un COKLU ticker ciktisi.
+
+    Kolonlar (Price, Ticker) MultiIndex'idir; `group_by="column"` varsayilani
+    ile ust seviye 'Close', 'Open' gibi alan adlaridir.
+    """
+    uzunluk = len(next(iter(kapanislar.values())))
+    indeks = pd.date_range("2026-08-19 10:00", periods=uzunluk, freq="min")
+
+    veri: dict[tuple[str, str], list[float]] = {}
+    for ticker, seri in kapanislar.items():
+        veri[("Close", ticker)] = seri
+        # Gercek ciktida baska alanlar da vardir; kod yalnizca Close okumali.
+        veri[("Open", ticker)] = [0.0] * uzunluk
+
+    df = pd.DataFrame(veri, index=indeks)
+    df.columns = pd.MultiIndex.from_tuples(df.columns, names=["Price", "Ticker"])
+    return df
+
+
+def _tek_ticker_duz_df(kapanis: list[float]) -> pd.DataFrame:
+    """`multi_level_index=False` (veya eski yfinance) ciktisi: DUZ kolonlar.
+
+    Bu bicimde `df["Close"]` bir Series'tir, DataFrame degil.
+    """
+    indeks = pd.date_range("2026-08-19 10:00", periods=len(kapanis), freq="min")
+    return pd.DataFrame({"Close": kapanis, "Open": [0.0] * len(kapanis)}, index=indeks)
+
+
+def test_coklu_ticker_son_kapanislari_cozulur():
+    df = _coklu_ticker_df({"THYAO.IS": [300.0, 301.5], "AAPL": [215.0, 216.25]})
+
+    sonuc = yahoo._son_fiyatlar(df, ["AAPL", "THYAO.IS"])
+
+    assert sonuc == {"THYAO.IS": 301.5, "AAPL": 216.25}
+
+
+def test_son_satir_bossa_bir_onceki_gecerli_kapanis_alinir():
+    """Intraday veride son mumlar cogu zaman NaN gelir - atlanmalidir."""
+    df = _coklu_ticker_df({"THYAO.IS": [300.0, 301.5, NAN, NAN]})
+
+    sonuc = yahoo._son_fiyatlar(df, ["THYAO.IS"])
+
+    assert sonuc == {"THYAO.IS": 301.5}
+
+
+def test_tamamen_bos_ticker_sonuca_girmez():
+    """Bir sembol gelmezse digerleri yine de donmeli (kismi basari)."""
+    df = _coklu_ticker_df({"THYAO.IS": [300.0, 301.5], "SOL-USD": [NAN, NAN]})
+
+    sonuc = yahoo._son_fiyatlar(df, ["SOL-USD", "THYAO.IS"])
+
+    assert sonuc == {"THYAO.IS": 301.5}
+
+
+def test_sifir_kapanis_gecerli_sayilmaz():
+    """0 fiyat gercek bir kotasyon degildir; yazilirsa dashboard bozulur."""
+    df = _coklu_ticker_df({"THYAO.IS": [300.0, 0.0]})
+
+    assert yahoo._son_fiyatlar(df, ["THYAO.IS"]) == {}
+
+
+def test_tek_ticker_duz_bicim_de_cozulur():
+    """`Close` Series geldiginde ticker adi listeden alinir."""
+    df = _tek_ticker_duz_df([300.0, 301.5])
+
+    sonuc = yahoo._son_fiyatlar(df, ["THYAO.IS"])
+
+    assert sonuc == {"THYAO.IS": 301.5}
+
+
+def test_bos_dataframe_bos_sozluk_dondurur():
+    assert yahoo._son_fiyatlar(pd.DataFrame(), ["THYAO.IS"]) == {}
+
+
+def test_none_bos_sozluk_dondurur():
+    """yfinance hata durumunda `None` donebilir; istisna firlatilmamali."""
+    assert yahoo._son_fiyatlar(None, ["THYAO.IS"]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Sembol tablosu senkronu
+# ---------------------------------------------------------------------------
+
+
+def _borsa_verisi_symbols():
+    """`borsa-verisi/symbols.py`'yi dosya yolundan yukler.
+
+    `borsa-verisi/` bir paket DEGILDIR ve backend onu import etmez; bu yuzden
+    normal `import` calismaz. Klasor yoksa (backend tek basina kullanildiginda)
+    test atlanir.
+    """
+    yol = Path(__file__).resolve().parents[2] / "borsa-verisi" / "symbols.py"
+    if not yol.exists():
+        pytest.skip("borsa-verisi/ bu kopyada yok")
+
+    spec = importlib.util.spec_from_file_location("borsa_verisi_symbols", yol)
+    modul = importlib.util.module_from_spec(spec)
+    # `sys.modules`'a ONCE yazilmali: `symbols.py` `from __future__ import
+    # annotations` kullaniyor ve @dataclass alan tiplerini cozerken modulu
+    # `sys.modules` uzerinden ariyor - kayitli degilse AttributeError verir.
+    sys.modules[spec.name] = modul
+    spec.loader.exec_module(modul)
+    return modul
+
+
+def test_sembol_tablosu_borsa_verisi_ile_ayni():
+    """AYNI ESLEME IKI YERDE DURUYOR - ayrisirlarsa burasi kirmizi yanar.
+
+    `app/market/yahoo.py` canli fiyati, `borsa-verisi/symbols.py` gecmis
+    veriyi ceker. Biri duzeltilip digeri unutulursa grafikteki gecmis seri ile
+    canli fiyat FARKLI enstrumanlardan gelir ve bu sessizce olur.
+    """
+    symbols = _borsa_verisi_symbols()
+
+    dogrudan = {e.db_symbol: e.yahoo_ticker for e in symbols.ESLESMELER if not e.turetilmis}
+    turetilmis = {e.db_symbol: e.yahoo_ticker for e in symbols.ESLESMELER if e.turetilmis}
+
+    assert yahoo.YAHOO_TICKERS == dogrudan
+    assert yahoo.TURETILMIS_GRAM_TRY == turetilmis
+
+
+def test_troy_ons_sabiti_iki_yerde_ayni():
+    """Sabit ayrisirsa gram altin fiyati iki kaynakta farkli cikar."""
+    symbols = _borsa_verisi_symbols()
+
+    assert yahoo.TROY_ONS_GRAM == symbols.TROY_ONS_GRAM
+    assert yahoo.USDTRY_TICKER == symbols.USDTRY_TICKER

--- a/backend/tests/test_yahoo_client.py
+++ b/backend/tests/test_yahoo_client.py
@@ -1,0 +1,144 @@
+"""Yahoo canli fiyat istemcisinin saf mantigi (`app/market/yahoo.py`).
+
+BU TESTLER AGA CIKMAZ: yalnizca sembol eslemesi, ticker listesi uretimi ve
+gram/TRY turetmesi sinanir. Gercek indirme `_indir` icinde izole edilmistir.
+
+Kritik davranislar:
+  * Turetilmis varlik istendiginde USD/TRY kuru OTOMATIK istege eklenir;
+    eklenmezse gram altin fiyati hesaplanamaz.
+  * Kur veya ons fiyati eksikse turetilmis varlik sonuca EKLENMEZ - yanlis
+    fiyat yazmaktansa eski fiyat korunur.
+"""
+
+import pytest
+
+from app.market import yahoo
+
+# ---------------------------------------------------------------------------
+# Sembol eslemesi
+# ---------------------------------------------------------------------------
+
+
+def test_bist_hisseleri_is_ekiyle_eslenir():
+    for sembol in ("THYAO", "GARAN", "TCELL", "SASA", "ASELS", "EREGL"):
+        assert yahoo.YAHOO_TICKERS[sembol].endswith(".IS")
+
+
+def test_desteklenen_semboller_turetilmisleri_de_icerir():
+    desteklenen = yahoo.desteklenen_semboller()
+
+    assert "THYAO" in desteklenen
+    assert "GRAM_ALTIN" in desteklenen  # turetilmis
+    assert "GUMUS" in desteklenen
+    assert "TR10Y" not in desteklenen  # Yahoo'da guvenilir karsiligi yok
+
+
+def test_altin_ve_gumus_dogrudan_eslenmez():
+    """Yahoo'da TRY/gram sembolu yoktur; bunlar turetilir."""
+    assert "GRAM_ALTIN" not in yahoo.YAHOO_TICKERS
+    assert "GUMUS" not in yahoo.YAHOO_TICKERS
+    assert yahoo.TURETILMIS_GRAM_TRY["GRAM_ALTIN"] == "GC=F"
+
+
+# ---------------------------------------------------------------------------
+# Ticker listesi
+# ---------------------------------------------------------------------------
+
+
+def test_dogrudan_semboller_icin_ticker_uretilir():
+    assert yahoo.gerekli_tickerlar(["THYAO", "AAPL"]) == ["AAPL", "THYAO.IS"]
+
+
+def test_turetilmis_sembol_kur_tickerini_de_ekler():
+    """KRITIK: USD/TRY olmadan gram fiyati hesaplanamaz."""
+    tickerlar = yahoo.gerekli_tickerlar(["GRAM_ALTIN"])
+
+    assert "GC=F" in tickerlar
+    assert yahoo.USDTRY_TICKER in tickerlar
+
+
+def test_turetme_yoksa_kur_gereksiz_yere_eklenmez():
+    tickerlar = yahoo.gerekli_tickerlar(["THYAO"])
+
+    assert yahoo.USDTRY_TICKER not in tickerlar
+
+
+def test_bilinmeyen_sembol_sessizce_atlanir():
+    assert yahoo.gerekli_tickerlar(["YOKBOYLE", "THYAO"]) == ["THYAO.IS"]
+
+
+def test_ayni_ticker_tekrar_edilmez():
+    """USD/TRY hem varlik hem turetme girdisi olabilir; liste benzersizdir."""
+    tickerlar = yahoo.gerekli_tickerlar(["USD/TRY", "GRAM_ALTIN"])
+
+    assert tickerlar.count(yahoo.USDTRY_TICKER) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fiyat turetme
+# ---------------------------------------------------------------------------
+
+
+def test_dogrudan_fiyat_oldugu_gibi_aktarilir():
+    sonuc = yahoo.fiyatlari_turet({"THYAO.IS": 301.2534567}, ["THYAO"])
+
+    assert sonuc == {"THYAO": 301.2535}  # 4 basamaga yuvarlanir
+
+
+def test_gram_altin_ons_ve_kurdan_hesaplanir():
+    # 3110.34768 / 31.1034768 = tam 100 USD/gram; 100 * 40 = 4000 TRY/gram
+    ham = {"GC=F": 3110.34768, yahoo.USDTRY_TICKER: 40.0}
+
+    sonuc = yahoo.fiyatlari_turet(ham, ["GRAM_ALTIN"])
+
+    assert sonuc["GRAM_ALTIN"] == pytest.approx(4000.0)
+
+
+def test_gercekci_degerlerle_gram_altin_makul_cikar():
+    ham = {"GC=F": 4451.60, yahoo.USDTRY_TICKER: 47.9163}
+
+    sonuc = yahoo.fiyatlari_turet(ham, ["GRAM_ALTIN"])
+
+    assert 6000 < sonuc["GRAM_ALTIN"] < 8000
+
+
+def test_kur_yoksa_turetilmis_varlik_atlanir():
+    """Yanlis fiyat yazmaktansa eski fiyat korunur."""
+    sonuc = yahoo.fiyatlari_turet({"GC=F": 4451.60}, ["GRAM_ALTIN"])
+
+    assert "GRAM_ALTIN" not in sonuc
+
+
+def test_ons_fiyati_yoksa_turetilmis_varlik_atlanir():
+    sonuc = yahoo.fiyatlari_turet({yahoo.USDTRY_TICKER: 47.9}, ["GRAM_ALTIN"])
+
+    assert "GRAM_ALTIN" not in sonuc
+
+
+def test_eksik_fiyat_digerlerini_engellemez():
+    """Bir sembol gelmezse digerleri yine de dondurulur (kismi basari)."""
+    ham = {"THYAO.IS": 301.25}
+
+    sonuc = yahoo.fiyatlari_turet(ham, ["THYAO", "AAPL", "GRAM_ALTIN"])
+
+    assert sonuc == {"THYAO": 301.25}
+
+
+def test_sifir_fiyat_gecerli_sayilmaz():
+    sonuc = yahoo.fiyatlari_turet({"THYAO.IS": 0}, ["THYAO"])
+
+    assert sonuc == {}
+
+
+# ---------------------------------------------------------------------------
+# Bos girdi
+# ---------------------------------------------------------------------------
+
+
+async def test_bos_sembol_listesi_ag_cagrisi_yapmaz():
+    """Istenecek sembol yoksa Yahoo'ya HIC gidilmemeli."""
+    assert await yahoo.canli_fiyatlar([]) == {}
+
+
+async def test_yalnizca_desteklenmeyen_sembollerde_cagri_yapilmaz():
+    assert await yahoo.canli_fiyatlar(["TR10Y", "YOKBOYLE"]) == {}

--- a/borsa-verisi/README.md
+++ b/borsa-verisi/README.md
@@ -1,0 +1,178 @@
+# borsa-verisi — Yahoo Finance → PostgreSQL veri toplama
+
+Veritabanındaki **2 · Varlık & Piyasa** tablolarını gerçek piyasa verisiyle
+**bir kez** dolduran bağımsız betik. Amaç: ajanları sentetik dummy data yerine
+gerçek fiyatlar üzerinde test edebilmek.
+
+> **Bu klasör uygulamanın parçası değildir.** `backend/app/` içindeki hiçbir
+> dosyaya dokunmaz, import edilmez, CI'da çalışmaz. Periyodik fiyat güncellemesi
+> ayrı bir sorumluluktur ve `backend/app/market/scheduler.py` içindedir.
+
+---
+
+## Ne yapar
+
+| Tablo | İşlem | Ne yazılır |
+|---|---|---|
+| `assets` | UPDATE | `current_price`, `prev_close`, `daily/weekly/yearly_change_pct`, `price_updated_at` |
+| `price_history` | INSERT | Günlük kapanışlar, `source='api'` |
+| `market_api_usage` | UPSERT | Günlük çağrı sayacı |
+
+**Dokunulmayanlar:** portföy, sohbet, RAG, kullanıcı tabloları. `assets`
+tablosunda da yalnızca fiyat sütunları güncellenir — `symbol`, `name`,
+`category_id`, `currency` değiştirilmez. Veritabanında olmayan bir sembol
+gelirse **atlanır**, yeni varlık yaratılmaz.
+
+---
+
+## Kurulum ve çalıştırma
+
+```bash
+cd borsa-verisi
+pip install -r requirements.txt
+```
+
+```bash
+python collect.py --kuru-calistir
+```
+
+Önce **her zaman** kuru çalıştırma yapın: Yahoo'dan gerçek veriyi çeker,
+veritabanına ne yazılacağını gösterir, **hiçbir şey yazmaz**. Veritabanı
+sürücüsü kurulu olmasa bile çalışır.
+
+```bash
+python collect.py
+```
+
+Gerçek çalıştırma. Bağlantı adresi sırayla: `--dsn` → `DATABASE_URL` ortam
+değişkeni → `postgresql://finans:finans@localhost:5432/finans`.
+
+Tüm yazma **tek işlemde** yapılır: bir hata olursa hiçbir değişiklik kalıcı
+olmaz (rollback).
+
+### Seçenekler
+
+| Bayrak | Ne yapar |
+|---|---|
+| `--kuru-calistir` | Veritabanına yazmaz, yalnızca gösterir |
+| `--kategori STOCK GOLD` | Yalnızca seçilen grupları çeker |
+| `--period 5y` | Yahoo geçmiş aralığı (varsayılan `2y`) |
+| `--gecmis-yok` | `price_history`'ye yazmaz, sadece `assets` |
+| `--volatilite-guncelle` | `sim_volatility`'yi gerçek oynaklıkla günceller |
+| `--dsn ...` | PostgreSQL adresi |
+
+---
+
+## Sembol eşlemesi
+
+`symbols.py` tek kaynaktır. 16 varlık eşlenmiştir (13'ü varsayılan çalıştırmada, 3 kripto `--kategori CRYPTO` ile):
+
+| Grup | Semboller | Yahoo |
+|---|---|---|
+| `STOCK` | THYAO, GARAN, TCELL, SASA, ASELS, EREGL | `.IS` eki (`THYAO.IS`) |
+| `FOREX` | USD/TRY, EUR/TRY | `USDTRY=X`, `EURTRY=X` |
+| `GOLD` | GRAM_ALTIN, GUMUS | **türetilmiş** — aşağı bakın |
+| `USA_STOCK` | AAPL, TSLA, NVDA | doğrudan |
+| `CRYPTO` | BTC, ETH, SOL | `BTC-USD` — varsayılanda **kapalı**, `--kategori CRYPTO` ile çekilir |
+
+> **`TR10Y` (tahvil) veritabanından tamamen silindi** (16 Ağustos 2026).
+> Yahoo'da Türkiye 10 yıllık tahvil getirisi için sürekli/güvenilir veri
+> dönen bir sembol yoktu; dummy veri olarak kalması yerine kaldırılması
+> tercih edildi. Silmeden önce bağlı portföy/işlem/alarm/izleme kaydı
+> olmadığı doğrulandı. Tahvil verisi ileride ayrı bir kaynaktan ele alınabilir.
+
+### Altın ve gümüş neden türetiliyor?
+
+Yahoo'da "TRY cinsinden gram altın" diye bir sembol **yoktur**. Fiyat şöyle
+hesaplanır:
+
+```
+gram_TRY = (ons_USD / 31.1034768) × USD/TRY
+```
+
+Örnek: 4458.10 USD/ons ÷ 31.1034768 = 143.33 USD/gram × 47.8960 = **6.864 TL/gram**
+
+Kaynak `GC=F` (COMEX altın vadeli) ve `SI=F` (gümüş vadeli). Bu **saf maden**
+değeridir — kuyumcu makası ve işçilik payı **içermez**, bu yüzden kuyumcuda
+görülen fiyattan bir miktar düşüktür. Vadeli fiyat spot fiyattan küçük bir
+primle işlem görür.
+
+Altın ve gümüş için USD/TRY serisi bir kez çekilip yeniden kullanılır. İki
+seri farklı günlerde işlem görebildiği için (vadeli piyasa Pazar akşamı açılır,
+döviz neredeyse kesintisiz) kur serisi altın tarihlerine hizalanır ve boşluklar
+**son bilinen kurla** doldurulur — kur uydurulmaz.
+
+---
+
+## Metrik kuralları
+
+Şemadaki (`db/v5_schema_and_data.sql` bölüm 2) sözleşmeye uyulur:
+
+| Alan | Nasıl hesaplanır |
+|---|---|
+| `current_price` | Serinin son kapanışı |
+| `prev_close` | Bir önceki kapanış |
+| `daily_change_pct` | `(current / prev_close − 1) × 100` |
+| `weekly_change_pct` | 7 **takvim** günü öncesine göre |
+| `yearly_change_pct` | 365 **takvim** günü öncesine göre |
+| `price_updated_at` | Yazma anında `now()` |
+
+Şemadaki `prev_close = current_price / (1 + daily_change_pct/100)` bağı
+korunur — iki değer de aynı seriden türer.
+
+> ⚠️ **Takvim günü ≠ işlem günü.** Borsa hafta sonu ve tatilde kapalıdır;
+> "7 satır geriye git" yanlış sonuç verir. Referans, hedef tarihteki **veya
+> ondan önceki** en yakın işlem günüdür. Seri o tarihe kadar geriye gitmiyorsa
+> değer `None` kalır — **uydurulmaz**.
+
+> ⚠️ **`--period 1y` tuzağı.** Yıllık değişim 365 gün öncesine bakar; `1y`
+> verilirse seri tam o tarihte başladığı için referans bulunamaz ve yıllık
+> değişim boş kalır. Varsayılan bu yüzden `2y`'dir.
+
+`sim_volatility` **varsayılan olarak güncellenmez**: bu alan simülatörün adım
+büyüklüğüdür, gerçek veriyle değiştirmek demo davranışını değiştirir.
+`--volatilite-guncelle` ile açıkça istenebilir.
+
+---
+
+## Bilinmesi gerekenler
+
+**Gerçek fiyatlar dummy data'dan çok farklı.** Örneğin şemada `SASA` 45.20 TL,
+gerçekte ~2.36 TL (sermaye artırımı); `GRAM_ALTIN` 2.550 TL, gerçekte ~6.858 TL;
+`USD/TRY` 33.55, gerçekte ~47.90. Bu betik çalıştıktan sonra **portföy
+değerleri tamamen değişir** — `db/README.md`'deki "Portföy 1 ≈ 1,64M TL"
+doğrulaması artık tutmayacaktır. Beklenen davranıştır.
+
+**Sentetik `backfill` satırları silinmez.** `price_history` içinde eski
+`source='backfill'` satırları (90 gün × 4 saat) durmaya devam eder ve yeni
+`source='api'` satırlarıyla birlikte grafikte görünür. İstenirse elle
+temizlenebilir:
+
+```sql
+DELETE FROM price_history WHERE source = 'backfill';
+```
+
+Betik bu silmeyi **kendisi yapmaz** — veri silmek geri alınamaz.
+
+**Tekrar çalıştırılabilir.** `price_history` `ON CONFLICT (asset_id, ts)` ile
+yazılır, aynı gün ikinci kez çalıştırmak hata vermez.
+
+**Yahoo resmî bir API değildir.** `yfinance` Yahoo'nun genel uçlarını kullanır;
+sembol adları ve veri sürekliliği garanti değildir. Art arda hızlı istek geçici
+engellemeye yol açabildiği için çağrılar arasında 0.4 sn beklenir.
+
+---
+
+## Testler
+
+```bash
+python -m pytest tests/ -q
+```
+
+36 test — **ağ ve veritabanı gerektirmez**. Hesaplama mantığını (takvim günü
+referansı, altın türetmesi, yıllık değişim sınırı) ve SQL sözleşmesini
+(kapsam dışı tabloya yazmama, tekrar çalıştırılabilirlik) sabitler.
+
+> Gerçek veritabanına yazma yolu **canlı olarak test edilmemiştir** — bu
+> makinede PostgreSQL ayakta değil. İlk gerçek çalıştırmayı `--kuru-calistir`
+> sonrası, tercihen yedeği alınmış bir veritabanında yapın.

--- a/borsa-verisi/README.md
+++ b/borsa-verisi/README.md
@@ -169,10 +169,15 @@ engellemeye yol açabildiği için çağrılar arasında 0.4 sn beklenir.
 python -m pytest tests/ -q
 ```
 
-36 test — **ağ ve veritabanı gerektirmez**. Hesaplama mantığını (takvim günü
+44 test — **ağ ve veritabanı gerektirmez**. Hesaplama mantığını (takvim günü
 referansı, altın türetmesi, yıllık değişim sınırı) ve SQL sözleşmesini
 (kapsam dışı tabloya yazmama, tekrar çalıştırılabilirlik) sabitler.
 
-> Gerçek veritabanına yazma yolu **canlı olarak test edilmemiştir** — bu
-> makinede PostgreSQL ayakta değil. İlk gerçek çalıştırmayı `--kuru-calistir`
-> sonrası, tercihen yedeği alınmış bir veritabanında yapın.
+Testler **CI'da da koşar**: `.github/workflows/backend-ci.yml` içindeki
+`borsa-verisi` job'ı ruff + black + pytest çalıştırır. (Backend job'ının her
+adımı `working-directory: backend` olduğu için bu klasör ayrı bir job ister —
+aksi halde buradaki kod hiç kontrol edilmezdi.)
+
+> Sembol eşlemesi (`symbols.py`) backend'deki `app/market/yahoo.py` ile aynı
+> tabloyu tutar. İkisi elle senkron tutulur; ayrışırlarsa backend'deki
+> `test_sembol_tablosu_borsa_verisi_ile_ayni` testi CI'da hata verir.

--- a/borsa-verisi/collect.py
+++ b/borsa-verisi/collect.py
@@ -1,0 +1,195 @@
+"""Yahoo Finance -> PostgreSQL tek seferlik veri toplama betigi.
+
+KULLANIM
+    python collect.py --kuru-calistir      # veritabanina YAZMAZ, ne yazacagini gosterir
+    python collect.py                      # gercek calistirma (hisse+doviz+altin+ABD)
+    python collect.py --kategori STOCK GOLD
+    python collect.py --period 2y
+    python collect.py --volatilite-guncelle
+
+TASARIM NOTU
+    Bu bir ARKA PLAN GOREVI DEGILDIR. Periyodik guncelleme
+    `backend/app/market/scheduler.py` sorumlulugundadir ve bu betik oraya
+    baglanmaz. Buradaki amac: veritabanini bir kez gercek piyasa verisiyle
+    doldurup ajanlarin gercek veri uzerinde test edilebilmesini saglamak.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from symbols import ESLENMEYEN_SEMBOLLER, VARSAYILAN_KATEGORILER, eslesmeleri_getir
+from yahoo import ToplamaSonucu, varliklari_topla
+
+# NOT: `database` modulu BILINCLI olarak burada import EDILMEZ. Kuru
+# calistirma veritabanina hic dokunmadigi icin psycopg surucusu kurulu
+# olmadan da calisabilmelidir; import yazma anina ertelenir.
+
+logger = logging.getLogger("borsa-verisi")
+
+
+def _argumanlar() -> argparse.Namespace:
+    ayristirici = argparse.ArgumentParser(
+        description="Yahoo Finance'ten hisse/altin/doviz verisi cekip veritabanina yazar.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ayristirici.add_argument(
+        "--kategori",
+        nargs="+",
+        metavar="KOD",
+        help=f"Toplanacak kategoriler. Varsayilan: {' '.join(VARSAYILAN_KATEGORILER)}. "
+        "Secenekler: STOCK FOREX GOLD USA_STOCK CRYPTO",
+    )
+    ayristirici.add_argument(
+        "--period",
+        default="2y",
+        help="Yahoo gecmis araligi (1mo, 3mo, 6mo, 1y, 2y, 5y, max). Varsayilan: 2y.\n"
+        "DIKKAT: yearly_change_pct 365 gun oncesine bakar; '1y' verilirse seri "
+        "tam o tarihte basladigi icin yillik degisim BOS kalir. En az '2y' gerekir.",
+    )
+    ayristirici.add_argument(
+        "--kuru-calistir",
+        action="store_true",
+        help="Veritabanina HIC yazma; yalnizca ne yazilacagini goster.",
+    )
+    ayristirici.add_argument(
+        "--gecmis-yok",
+        action="store_true",
+        help="price_history'ye yazma, yalnizca assets tablosunu guncelle.",
+    )
+    ayristirici.add_argument(
+        "--volatilite-guncelle",
+        action="store_true",
+        help="assets.sim_volatility alanini gercek oynaklikla guncelle "
+        "(simulator davranisini degistirir - varsayilan KAPALI).",
+    )
+    ayristirici.add_argument("--dsn", help="PostgreSQL adresi. Varsayilan: DATABASE_URL")
+    return ayristirici.parse_args()
+
+
+def _tablo_yazdir(sonuc: ToplamaSonucu) -> None:
+    """Cekilen veriyi okunabilir bir tabloda gosterir."""
+    baslik = (
+        f"{'SEMBOL':<12}{'FIYAT':>14}{'GUNLUK':>10}{'HAFTALIK':>11}"
+        f"{'YILLIK':>10}{'OYNAKLIK':>11}{'GECMIS':>9}"
+    )
+    print("\n" + baslik)
+    print("-" * len(baslik))
+
+    for veri in sorted(sonuc.veriler, key=lambda v: (v.kategori, v.db_symbol)):
+        isaret = " *" if veri.turetilmis else ""
+        print(
+            f"{veri.db_symbol + isaret:<12}"
+            f"{veri.current_price:>14,.4f}"
+            f"{_yuzde(veri.daily_change_pct):>10}"
+            f"{_yuzde(veri.weekly_change_pct):>11}"
+            f"{_yuzde(veri.yearly_change_pct):>10}"
+            f"{veri.volatilite if veri.volatilite is not None else '-':>11}"
+            f"{len(veri.gecmis):>9}"
+        )
+
+    if any(v.turetilmis for v in sonuc.veriler):
+        print("\n  * = turetilmis fiyat (ons/USD -> gram/TRY, saf maden; iscilik haric)")
+
+
+def _yuzde(deger: float | None) -> str:
+    return "-" if deger is None else f"{deger:+.2f}%"
+
+
+def _dsn_maskele(dsn: str) -> str:
+    """Baglanti adresini ekrana basmadan once sifreyi gizler.
+
+    `postgresql://kullanici:SIFRE@host/db` -> `postgresql://kullanici:***@host/db`.
+    Loglarda/terminalde parola acikca gorunmesin diye.
+    """
+    if "://" not in dsn or "@" not in dsn:
+        return dsn
+    on, arka = dsn.split("@", 1)
+    if ":" not in on:
+        return dsn
+    kullanici_kismi = on.rsplit(":", 1)[0]
+    return f"{kullanici_kismi}:***@{arka}"
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+    args = _argumanlar()
+
+    eslesmeler = eslesmeleri_getir(args.kategori)
+    if not eslesmeler:
+        print("HATA: Secilen kategoride varlik yok.", file=sys.stderr)
+        return 1
+
+    print(f"Yahoo Finance'ten {len(eslesmeler)} varlik cekiliyor (period={args.period})...")
+    sonuc = varliklari_topla(eslesmeler, period=args.period)
+
+    if sonuc.veriler:
+        _tablo_yazdir(sonuc)
+
+    if sonuc.hatalar:
+        print("\nCEKILEMEYEN VARLIKLAR:")
+        for sembol, hata in sonuc.hatalar:
+            print(f"  - {sembol}: {hata}")
+
+    if ESLENMEYEN_SEMBOLLER:
+        print(
+            "\nEslenmemis semboller (Yahoo'da guvenilir karsiligi yok): "
+            + ", ".join(ESLENMEYEN_SEMBOLLER)
+        )
+
+    if not sonuc.veriler:
+        print("\nHicbir varlik cekilemedi, veritabanina yazilmadi.", file=sys.stderr)
+        return 1
+
+    toplam_gecmis = sum(len(v.gecmis) for v in sonuc.veriler)
+
+    if args.kuru_calistir:
+        print(
+            f"\n[KURU CALISTIRMA] Veritabanina YAZILMADI.\n"
+            f"  Gercek calistirmada guncellenecek: {len(sonuc.veriler)} varlik "
+            f"(assets tablosu)\n"
+            f"  price_history'ye eklenecek satir: "
+            f"{0 if args.gecmis_yok else toplam_gecmis}\n"
+            f"  Yahoo cagri sayisi: {sonuc.cagri_sayisi}"
+        )
+        return 0
+
+    try:
+        from database import api_kullanimi_kaydet, baglan, dsn_getir, varliklari_yaz
+    except ImportError as exc:
+        print(f"\nHATA: PostgreSQL surucusu yuklenemedi ({exc}).", file=sys.stderr)
+        print("Kurulum: pip install -r requirements.txt", file=sys.stderr)
+        print("Veritabani olmadan denemek icin: --kuru-calistir", file=sys.stderr)
+        return 1
+
+    print(f"\nVeritabanina yaziliyor: {_dsn_maskele(dsn_getir(args.dsn))}")
+    try:
+        with baglan(args.dsn) as conn:
+            yazma = varliklari_yaz(
+                conn,
+                sonuc.veriler,
+                gecmis_yaz=not args.gecmis_yok,
+                volatilite_guncelle=args.volatilite_guncelle,
+            )
+            api_kullanimi_kaydet(conn, sonuc.cagri_sayisi)
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001 - kullaniciya net mesaj gosterilir
+        print(f"\nVERITABANI HATASI: {exc}", file=sys.stderr)
+        print("Hicbir degisiklik kaydedilmedi (islem geri alindi).", file=sys.stderr)
+        return 1
+
+    print(
+        f"\nTAMAMLANDI\n"
+        f"  assets guncellenen satir : {yazma.guncellenen_varlik}\n"
+        f"  price_history yazilan    : {yazma.yazilan_gecmis}\n"
+        f"  Yahoo cagri sayisi       : {sonuc.cagri_sayisi}"
+    )
+    if yazma.bulunamayan_semboller:
+        print("  Veritabaninda BULUNAMAYAN: " + ", ".join(yazma.bulunamayan_semboller))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/borsa-verisi/database.py
+++ b/borsa-verisi/database.py
@@ -1,0 +1,248 @@
+"""PostgreSQL yazma katmani - yalnizca bolum 2 (Varlik & Piyasa) tablolari.
+
+DOKUNULAN TABLOLAR
+    assets            -> UPDATE (fiyat ve degisim metrikleri)
+    price_history     -> INSERT (source='api')
+    market_api_usage  -> UPSERT (gunluk cagri sayaci)
+
+DOKUNULMAYAN HER SEY
+    Portfoy, sohbet, RAG ve kullanici tablolarina HIC yazilmaz. `assets`
+    tablosunda da yalnizca fiyat sutunlari guncellenir; `symbol`, `name`,
+    `category_id` ve `currency` DEGISTIRILMEZ.
+
+NEDEN INSERT DEGIL UPDATE?
+    Varliklar semanin dummy data bolumunde zaten tanimli ve portfoy satirlari
+    `asset_id` ile onlara bagli. Yeni satir eklemek yerine mevcut satirlar
+    guncellenir; veritabaninda bilinmeyen bir sembol gelirse ATLANIR ve
+    raporda gosterilir - sessizce yeni varlik yaratilmaz.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+
+import psycopg
+
+from yahoo import PiyasaVerisi
+
+logger = logging.getLogger(__name__)
+
+#: docker-compose.yml'deki gelistirme veritabani.
+VARSAYILAN_DSN = "postgresql://finans:finans@localhost:5432/finans"
+
+#: SQLAlchemy surucusu ("postgresql+psycopg://") psycopg'nin anlamadigi bir
+#: bicimdir; surucu eki temizlenir.
+_SURUCU_EKI = re.compile(r"^postgresql\+\w+://")
+
+
+@dataclass
+class YazmaSonucu:
+    """Bir yazma turunun ozeti."""
+
+    guncellenen_varlik: int = 0
+    yazilan_gecmis: int = 0
+    bulunamayan_semboller: list[str] = field(default_factory=list)
+    #: `assets` tablosunda olmadigi icin yazilamayan kolonlar.
+    atlanan_kolonlar: list[str] = field(default_factory=list)
+
+
+def dsn_getir(acik_dsn: str | None = None) -> str:
+    """Baglanti adresini cozer: parametre -> DATABASE_URL -> varsayilan."""
+    ham = acik_dsn or os.getenv("DATABASE_URL") or VARSAYILAN_DSN
+    return _SURUCU_EKI.sub("postgresql://", ham.strip())
+
+
+def baglan(dsn: str | None = None) -> psycopg.Connection:
+    """Veritabanina baglanir. Otomatik commit KAPALI - yazma tek islemde."""
+    return psycopg.connect(dsn_getir(dsn), autocommit=False)
+
+
+# ---------------------------------------------------------------------------
+# Okuma
+# ---------------------------------------------------------------------------
+
+
+def sembol_id_haritasi(conn: psycopg.Connection) -> dict[str, int]:
+    """`assets` tablosundaki sembol -> id eslemesi."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT symbol, id FROM assets")
+        return {satir[0]: satir[1] for satir in cur.fetchall()}
+
+
+# ---------------------------------------------------------------------------
+# Yazma
+# ---------------------------------------------------------------------------
+
+_ASSETS_UPDATE = """
+UPDATE assets SET
+    current_price     = %(current_price)s,
+    prev_close        = COALESCE(%(prev_close)s, prev_close),
+    daily_change_pct  = COALESCE(%(daily)s,  daily_change_pct),
+    weekly_change_pct = COALESCE(%(weekly)s, weekly_change_pct),
+    yearly_change_pct = COALESCE(%(yearly)s, yearly_change_pct),
+    price_updated_at  = now()
+WHERE symbol = %(symbol)s
+"""
+
+#: Oynaklik yalnizca `--volatilite-guncelle` ile istenirse yazilir; simulator
+#: davranisini degistirdigi icin varsayilan olarak DOKUNULMAZ.
+_ASSETS_UPDATE_VOLATILITE = _ASSETS_UPDATE.replace(
+    "price_updated_at  = now()",
+    "sim_volatility    = COALESCE(%(volatilite)s, sim_volatility),\n    price_updated_at  = now()",
+)
+
+#: `assets` tablosunda BULUNMAYABILECEK kolonlar -> yazilacak SQL parcasi.
+#:
+#: NEDEN: Repo semasi (`db/v5_schema_and_data.sql`) ile calisan veritabani
+#: her zaman birebir ayni olmayabilir. Ornegin Supabase'deki tabloda
+#: `prev_close`, `price_updated_at` ve `sim_volatility` yoktur. Var olmayan
+#: bir kolona yazmak TUM islemi iptal eder ve binlerce satirlik fiyat verisi
+#: geri alinir; bu yuzden UPDATE ifadesi calisma aninda semaya gore kurulur.
+_OPSIYONEL_KOLONLAR: dict[str, str] = {
+    "prev_close": "prev_close = COALESCE(%(prev_close)s, prev_close)",
+    "price_updated_at": "price_updated_at = now()",
+}
+
+#: Her zaman var oldugu varsayilan cekirdek kolonlar.
+_ZORUNLU_ATAMALAR: tuple[str, ...] = (
+    "current_price = %(current_price)s",
+    "daily_change_pct = COALESCE(%(daily)s, daily_change_pct)",
+    "weekly_change_pct = COALESCE(%(weekly)s, weekly_change_pct)",
+    "yearly_change_pct = COALESCE(%(yearly)s, yearly_change_pct)",
+)
+
+
+def mevcut_kolonlar(conn: psycopg.Connection, tablo: str) -> set[str]:
+    """Tablodaki kolon adlarini doner."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = %s",
+            (tablo,),
+        )
+        return {satir[0] for satir in cur.fetchall()}
+
+
+def assets_update_sorgusu(kolonlar: set[str], volatilite_guncelle: bool = False) -> str:
+    """Mevcut semaya gore UPDATE ifadesini kurar.
+
+    Eksik kolonlar sessizce ATLANIR - boylece betik hem repo semasinda hem
+    kolonlari eksik bir veritabaninda calisir.
+    """
+    atamalar = list(_ZORUNLU_ATAMALAR)
+
+    for kolon, ifade in _OPSIYONEL_KOLONLAR.items():
+        if kolon in kolonlar:
+            atamalar.append(ifade)
+
+    if volatilite_guncelle and "sim_volatility" in kolonlar:
+        atamalar.append("sim_volatility = COALESCE(%(volatilite)s, sim_volatility)")
+
+    return "UPDATE assets SET\n    " + ",\n    ".join(atamalar) + "\nWHERE symbol = %(symbol)s"
+
+
+_PRICE_HISTORY_INSERT = """
+INSERT INTO price_history (asset_id, ts, price, source)
+VALUES (%s, %s, %s, 'api')
+ON CONFLICT (asset_id, ts) DO UPDATE
+    SET price = EXCLUDED.price, source = EXCLUDED.source
+"""
+
+_API_USAGE_UPSERT = """
+INSERT INTO market_api_usage (usage_date, call_count, last_call_at)
+VALUES (CURRENT_DATE, %s, now())
+ON CONFLICT (usage_date) DO UPDATE
+    SET call_count   = market_api_usage.call_count + EXCLUDED.call_count,
+        last_call_at = now()
+"""
+
+
+def varliklari_yaz(
+    conn: psycopg.Connection,
+    veriler: list[PiyasaVerisi],
+    gecmis_yaz: bool = True,
+    volatilite_guncelle: bool = False,
+) -> YazmaSonucu:
+    """Fiyat verilerini veritabanina yazar.
+
+    Tum yazma TEK islemde yapilir: cagiran `commit()` etmezse hicbir sey
+    kalici olmaz. Boylece yarim yazilmis bir tur olusmaz.
+    """
+    sonuc = YazmaSonucu()
+    harita = sembol_id_haritasi(conn)
+
+    # Sorgu calisma aninda semaya gore kurulur; eksik kolonlar atlanir.
+    kolonlar = mevcut_kolonlar(conn, "assets")
+    sorgu = assets_update_sorgusu(kolonlar, volatilite_guncelle)
+    sonuc.atlanan_kolonlar = sorted((set(_OPSIYONEL_KOLONLAR) | {"sim_volatility"}) - kolonlar)
+    if sonuc.atlanan_kolonlar:
+        logger.warning(
+            "assets tablosunda bulunmayan kolonlar atlandi",
+            extra={"kolonlar": sonuc.atlanan_kolonlar},
+        )
+
+    with conn.cursor() as cur:
+        for veri in veriler:
+            asset_id = harita.get(veri.db_symbol)
+            if asset_id is None:
+                sonuc.bulunamayan_semboller.append(veri.db_symbol)
+                logger.warning("sembol veritabaninda yok", extra={"sembol": veri.db_symbol})
+                continue
+
+            parametreler = {
+                "symbol": veri.db_symbol,
+                "current_price": veri.current_price,
+                "prev_close": veri.prev_close,
+                "daily": veri.daily_change_pct,
+                "weekly": veri.weekly_change_pct,
+                "yearly": veri.yearly_change_pct,
+            }
+            if volatilite_guncelle:
+                parametreler["volatilite"] = veri.volatilite
+
+            cur.execute(sorgu, parametreler)
+            sonuc.guncellenen_varlik += cur.rowcount
+
+            if gecmis_yaz and veri.gecmis:
+                cur.executemany(
+                    _PRICE_HISTORY_INSERT,
+                    [(asset_id, ts, fiyat) for ts, fiyat in veri.gecmis],
+                )
+                sonuc.yazilan_gecmis += len(veri.gecmis)
+
+    return sonuc
+
+
+def tablo_var_mi(conn: psycopg.Connection, tablo: str) -> bool:
+    """Tablonun mevcut semada olup olmadigini soyler."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s) IS NOT NULL", (tablo,))
+        return bool(cur.fetchone()[0])
+
+
+def api_kullanimi_kaydet(conn: psycopg.Connection, cagri_sayisi: int) -> None:
+    """Gunluk cagri sayacini artirir (`market_api_usage`).
+
+    Yahoo resmi bir API degildir ve belgelenmis bir gunluk kotasi yoktur;
+    yine de sema bu tabloyu tanimladigi ve asiri cagri gecici engellemeye yol
+    actigi icin sayac tutulur.
+
+    TABLO YOKSA SESSIZCE ATLANIR: bu sayac bir yan kayittir, asil is fiyat
+    yazmaktir. Tablo bulunmadiginda PostgreSQL islemi (transaction) komple
+    iptal eder ve 6.500 satirlik fiyat verisi de geri alinirdi - sayac
+    ugruna asil veri kaybedilmez.
+    """
+    if cagri_sayisi <= 0:
+        return
+
+    if not tablo_var_mi(conn, "market_api_usage"):
+        logger.warning(
+            "market_api_usage tablosu yok, cagri sayaci atlandi " "(fiyat yazimi bundan ETKILENMEZ)"
+        )
+        return
+
+    with conn.cursor() as cur:
+        cur.execute(_API_USAGE_UPSERT, (cagri_sayisi,))

--- a/borsa-verisi/database.py
+++ b/borsa-verisi/database.py
@@ -97,10 +97,17 @@ _ASSETS_UPDATE_VOLATILITE = _ASSETS_UPDATE.replace(
 #: `assets` tablosunda BULUNMAYABILECEK kolonlar -> yazilacak SQL parcasi.
 #:
 #: NEDEN: Repo semasi (`db/v5_schema_and_data.sql`) ile calisan veritabani
-#: her zaman birebir ayni olmayabilir. Ornegin Supabase'deki tabloda
-#: `prev_close`, `price_updated_at` ve `sim_volatility` yoktur. Var olmayan
-#: bir kolona yazmak TUM islemi iptal eder ve binlerce satirlik fiyat verisi
-#: geri alinir; bu yuzden UPDATE ifadesi calisma aninda semaya gore kurulur.
+#: her zaman birebir ayni olmayabilir. Var olmayan bir kolona yazmak TUM
+#: islemi iptal eder ve binlerce satirlik fiyat verisi geri alinir; bu yuzden
+#: UPDATE ifadesi calisma aninda semaya gore kurulur.
+#:
+#: GECMIS NOT (16 Agustos 2026): ekibin paylasilan Supabase veritabaninda o
+#: tarihte `prev_close`, `price_updated_at` ve `sim_volatility` YOKTU ve bu
+#: mekanizma sayesinde toplama yine de tamamlandi. Bu KALICI bir durum
+#: DEGILDIR, giderilmesi gereken bir sema kaymasidir: backend'in fiyat gorevi
+#: (`app/repositories/sql.py`) bu kolonlari OPSIYONEL saymaz, dogrudan
+#: kullanir - eksiklerse fiyat guncelleme 15 dakikada bir hata verir.
+#: Kolonlari eklemek icin: `db/migrations/001_assets_fiyat_kolonlari.sql`.
 _OPSIYONEL_KOLONLAR: dict[str, str] = {
     "prev_close": "prev_close = COALESCE(%(prev_close)s, prev_close)",
     "price_updated_at": "price_updated_at = now()",

--- a/borsa-verisi/pyproject.toml
+++ b/borsa-verisi/pyproject.toml
@@ -1,0 +1,20 @@
+# Yalnizca ARAC AYARI - bu klasor bir Python paketi degildir, bagimsiz bir
+# betik klasorudur (bkz. README.md).
+#
+# NEDEN GEREKLI: black ve ruff ayarlarini dosyadan yukari dogru arar. Bu dosya
+# olmadan `borsa-verisi/` icinde calistirildiklarinda backend/pyproject.toml'u
+# BULAMAZLAR ve black varsayilan 88 karakter sinirina duser - ayni depoda iki
+# farkli bicim olusur. Degerler backend/pyproject.toml ile AYNI tutulur.
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.pytest.ini_options]
+# Testler ag ve veritabani GEREKTIRMEZ; hepsi saf mantik sinar.
+testpaths = ["tests"]

--- a/borsa-verisi/requirements.txt
+++ b/borsa-verisi/requirements.txt
@@ -16,7 +16,8 @@ yfinance==1.3.0
 
 # Zaman serisi hizalama ve metrik hesabi (yfinance zaten getirir, acikca
 # import ettigimiz icin sabitlendi) - backend/requirements.txt ile AYNI surum
-pandas==2.2.1
+# 2.2.1 DEGIL: Python 3.13 icin wheel'i yok, kaynaktan derleme patliyor.
+pandas==2.2.3
 
 # PostgreSQL surucusu - backend/requirements.txt ile AYNI surum
 psycopg[binary]==3.2.3

--- a/borsa-verisi/requirements.txt
+++ b/borsa-verisi/requirements.txt
@@ -1,18 +1,29 @@
 # Borsa verisi toplama betigi - BAGIMSIZ bagimliliklar.
 #
-# Bu dosya backend/requirements.txt'ten AYRIDIR: yfinance yalnizca bu tek
-# seferlik toplama isinde kullanilir, uygulamanin calisma zamaninda gerekmez.
-# Backend'e gereksiz bagimlilik eklememek icin bilincli olarak ayri tutuldu.
+# Bu dosya backend/requirements.txt'ten AYRIDIR cunku bu betik uygulamanin
+# PARCASI DEGILDIR: tek seferlik calisir, backend'i import etmez ve kendi
+# basina (backend kurulmadan) calistirilabilir olmasi istenir.
+#
+# NOT: yfinance artik backend'de DE var - canli fiyat katmani onu kullaniyor
+# (backend/app/market/yahoo.py). Yani bu ayrim "backend'e gereksiz bagimlilik
+# eklememek" icin degil, betigin bagimsiz kalmasi icindir. Ortak paketlerin
+# surumleri iki dosyada AYNI tutulur; ayrisirsa ayni kodun iki ortamda farkli
+# davranmasi riski dogar.
 
 # Yahoo Finance istemcisi (resmi olmayan; Yahoo'nun genel uclarini kullanir)
+# backend/requirements.txt ile AYNI surum
 yfinance==1.3.0
 
 # Zaman serisi hizalama ve metrik hesabi (yfinance zaten getirir, acikca
-# import ettigimiz icin sabitlendi)
+# import ettigimiz icin sabitlendi) - backend/requirements.txt ile AYNI surum
 pandas==2.2.1
 
 # PostgreSQL surucusu - backend/requirements.txt ile AYNI surum
 psycopg[binary]==3.2.3
 
-# Testler (ag ve veritabani gerektirmez)
+# Testler (ag ve veritabani gerektirmez) ve lint - CI bunlari kullanir
+# (.github/workflows/backend-ci.yml, `borsa-verisi` job'i).
+# Surumler backend/requirements.txt ile AYNI.
 pytest==8.4.2
+ruff==0.8.4
+black==24.10.0

--- a/borsa-verisi/requirements.txt
+++ b/borsa-verisi/requirements.txt
@@ -1,0 +1,18 @@
+# Borsa verisi toplama betigi - BAGIMSIZ bagimliliklar.
+#
+# Bu dosya backend/requirements.txt'ten AYRIDIR: yfinance yalnizca bu tek
+# seferlik toplama isinde kullanilir, uygulamanin calisma zamaninda gerekmez.
+# Backend'e gereksiz bagimlilik eklememek icin bilincli olarak ayri tutuldu.
+
+# Yahoo Finance istemcisi (resmi olmayan; Yahoo'nun genel uclarini kullanir)
+yfinance==1.3.0
+
+# Zaman serisi hizalama ve metrik hesabi (yfinance zaten getirir, acikca
+# import ettigimiz icin sabitlendi)
+pandas==2.2.1
+
+# PostgreSQL surucusu - backend/requirements.txt ile AYNI surum
+psycopg[binary]==3.2.3
+
+# Testler (ag ve veritabani gerektirmez)
+pytest==8.4.2

--- a/borsa-verisi/symbols.py
+++ b/borsa-verisi/symbols.py
@@ -1,0 +1,143 @@
+"""Veritabani sembolu <-> Yahoo Finance ticker eslemesi.
+
+Bu dosya bir SOZLESME tablosudur: `assets.symbol` sutunundaki her deger icin
+Yahoo'da hangi ticker'in cekilecegini soyler. Yeni bir varlik eklemek icin
+asagidaki listeye bir satir eklemek yeterlidir; toplama kodu degismez.
+
+NEDEN AYRI DOSYA?
+    Sembol eslemesi projedeki en kirilgan yerdir - Yahoo ticker'lari zaman
+    zaman degisir (`GC=F` -> baska bir kontrat gibi). Tek dosyada toplandiginda
+    duzeltme tek yerden yapilir.
+
+TURETILMIS VARLIKLAR
+    Yahoo'da "TRY cinsinden gram altin" diye bir sembol YOKTUR. Bu yuzden
+    GRAM_ALTIN ve GUMUS dogrudan cekilmez, su formulle turetilir:
+
+        gram_TRY = (ons_USD / 31.1034768) * USDTRY
+
+    Bu piyasa standardi "saf altin" hesabidir; kuyumcu makasi ve iscilik
+    payi ICERMEZ. Kullanicinin kuyumcuda gordugu fiyattan bir miktar dusuk
+    olmasi normaldir.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: 1 troy ons = 31.1034768 gram (uluslararasi kiymetli maden standardi).
+TROY_ONS_GRAM = 31.1034768
+
+#: Turetme yontemi: ons/USD fiyatini gram/TRY'ye cevir.
+TURETME_ONS_USD_GRAM_TRY = "ONS_USD_GRAM_TRY"
+
+#: Altin/gumus turetmesi ve USD varliklarin TRY karsiligi icin gereken kur.
+USDTRY_TICKER = "USDTRY=X"
+
+
+@dataclass(frozen=True)
+class VarlikEslesme:
+    """Bir `assets` satiri ile Yahoo ticker'i arasindaki bag.
+
+    Attributes:
+        db_symbol: `assets.symbol` sutunundaki DEGISMEZ deger. Toplama kodu
+            veritabanini bu alana gore gunceller.
+        kategori: `asset_categories.code` degeri. Yalnizca filtreleme ve
+            raporlama icin kullanilir; DB'deki kategori DEGISTIRILMEZ.
+        yahoo_ticker: Yahoo Finance sembolu.
+        turetme: `None` ise fiyat dogrudan Yahoo'dan alinir. Doluysa
+            `yahoo_ticker` ara girdidir ve fiyat hesaplanarak uretilir.
+        aciklama: Insan icin not - hangi enstruman cekiliyor.
+    """
+
+    db_symbol: str
+    kategori: str
+    yahoo_ticker: str
+    turetme: str | None = None
+    aciklama: str = ""
+
+    @property
+    def turetilmis(self) -> bool:
+        return self.turetme is not None
+
+
+#: Veritabanindaki varliklardan Yahoo'da karsiligi OLANLAR.
+#:
+#: KARAR (16 Agustos 2026): TR10Y (tahvil) veritabanindan TAMAMEN SILINDI.
+#: Yahoo'da Turkiye 10 yillik tahvil getirisi icin guvenilir, surekli veri
+#: donen bir sembol yoktu; dummy/mock veri olarak kalmasi yerine kaldirilmasi
+#: tercih edildi. Bagli portfoy/islem/alarm/izleme kaydi olmadigi dogrulanarak
+#: silindi. Tahvil verisi ileride ayri bir kaynaktan ele alinabilir.
+ESLESMELER: tuple[VarlikEslesme, ...] = (
+    # --- BIST hisseleri: Yahoo'da ".IS" eki ile ---------------------------
+    VarlikEslesme("THYAO", "STOCK", "THYAO.IS", aciklama="Turk Hava Yollari"),
+    VarlikEslesme("GARAN", "STOCK", "GARAN.IS", aciklama="Garanti BBVA"),
+    VarlikEslesme("TCELL", "STOCK", "TCELL.IS", aciklama="Turkcell"),
+    VarlikEslesme("SASA", "STOCK", "SASA.IS", aciklama="Sasa Polyester"),
+    VarlikEslesme("ASELS", "STOCK", "ASELS.IS", aciklama="Aselsan"),
+    VarlikEslesme("EREGL", "STOCK", "EREGL.IS", aciklama="Erdemir"),
+    # --- Doviz: Yahoo'da "=X" eki ile -------------------------------------
+    VarlikEslesme("USD/TRY", "FOREX", USDTRY_TICKER, aciklama="Amerikan Dolari"),
+    VarlikEslesme("EUR/TRY", "FOREX", "EURTRY=X", aciklama="Euro"),
+    # --- Kiymetli maden: TURETILMIS (bkz. modul docstring'i) --------------
+    VarlikEslesme(
+        "GRAM_ALTIN",
+        "GOLD",
+        "GC=F",
+        turetme=TURETME_ONS_USD_GRAM_TRY,
+        aciklama="COMEX altin vadeli (ons/USD) -> gram/TRY",
+    ),
+    VarlikEslesme(
+        "GUMUS",
+        "GOLD",
+        "SI=F",
+        turetme=TURETME_ONS_USD_GRAM_TRY,
+        aciklama="COMEX gumus vadeli (ons/USD) -> gram/TRY",
+    ),
+    # --- ABD hisseleri: dogrudan --------------------------------------------
+    VarlikEslesme("AAPL", "USA_STOCK", "AAPL", aciklama="Apple Inc."),
+    VarlikEslesme("TSLA", "USA_STOCK", "TSLA", aciklama="Tesla Inc."),
+    VarlikEslesme("NVDA", "USA_STOCK", "NVDA", aciklama="Nvidia"),
+    # --- Kripto: varsayilan calistirmada KAPALI ----------------------------
+    # Gorevin kapsaminda degil; `--kategori CRYPTO` ile acikca istenirse
+    # calisir. Fiyatlar USD cinsindendir (assets.currency = 'USD').
+    VarlikEslesme("BTC", "CRYPTO", "BTC-USD", aciklama="Bitcoin"),
+    VarlikEslesme("ETH", "CRYPTO", "ETH-USD", aciklama="Ethereum"),
+    VarlikEslesme("SOL", "CRYPTO", "SOL-USD", aciklama="Solana"),
+)
+
+#: `--kategori` verilmediginde toplanan gruplar. Kripto disarida: gorevde
+#: istenen kume hisse + altin + doviz + ABD hissesidir.
+VARSAYILAN_KATEGORILER: tuple[str, ...] = ("STOCK", "FOREX", "GOLD", "USA_STOCK")
+
+#: Yahoo'da guvenilir karsiligi olmadigi icin hic eslenmemis DB sembolleri.
+#: Raporda "atlandi" olarak gosterilir ki eksik veri sessizce kaybolmasin.
+#:
+#: Su an BOS: TR10Y (tek eslenmeyen sembol) 16 Agustos 2026'da veritabanindan
+#: silindi (bkz. ESLESMELER yorumu). Ileride Yahoo'da karsiligi olmayan yeni
+#: bir varlik eklenirse buraya yazilir; silinmez, cunku bu liste calisan
+#: raporlama kodu tarafindan kullanilir (bkz. collect.py).
+ESLENMEYEN_SEMBOLLER: tuple[str, ...] = ()
+
+
+def eslesmeleri_getir(kategoriler: list[str] | None = None) -> list[VarlikEslesme]:
+    """Istenen kategorilerdeki eslesmeleri doner.
+
+    Args:
+        kategoriler: `asset_categories.code` listesi. `None` ise
+            `VARSAYILAN_KATEGORILER` kullanilir.
+    """
+    secili = tuple(kategoriler) if kategoriler else VARSAYILAN_KATEGORILER
+    buyuk = {k.upper() for k in secili}
+    return [e for e in ESLESMELER if e.kategori in buyuk]
+
+
+def ons_usd_to_gram_try(ons_usd: float, usdtry: float) -> float:
+    """Ons/USD fiyatini gram/TRY'ye cevirir.
+
+    Ornek: 4458.10 USD/ons ve 47.8960 USD/TRY ->
+        4458.10 / 31.1034768 = 143.33 USD/gram
+        143.33 * 47.8960     = 6864.63 TRY/gram
+    """
+    if ons_usd <= 0 or usdtry <= 0:
+        raise ValueError("Ons fiyati ve USD/TRY kuru pozitif olmalidir.")
+    return (ons_usd / TROY_ONS_GRAM) * usdtry

--- a/borsa-verisi/tests/conftest.py
+++ b/borsa-verisi/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test modullerinin ust klasordeki modulleri import edebilmesi icin yol ayari.
+
+`borsa-verisi/` bir Python paketi degil, bagimsiz bir betik klasorudur; bu
+yuzden `symbols`, `yahoo` gibi moduller sys.path'e elle eklenir.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/borsa-verisi/tests/test_hesaplamalar.py
+++ b/borsa-verisi/tests/test_hesaplamalar.py
@@ -1,0 +1,222 @@
+"""Hesaplama mantigi testleri - AG ve VERITABANI GEREKTIRMEZ.
+
+Yahoo cagrisi ve DB yazimi burada test EDILMEZ; testler saf fonksiyonlari
+sabitler. Boylece internet olmadan da mantigin dogrulugu dogrulanabilir.
+
+Kritik davranislar:
+  * Haftalik/yillik degisim TAKVIM gunune gore hesaplanir (borsa hafta sonu
+    kapali oldugu icin "7 satir geriye git" yanlis sonuc verir).
+  * Seri yeterince geriye gitmiyorsa `None` doner - deger UYDURULMAZ.
+  * Gram altin turetmesinde kur bosluklari bir onceki gecerli kurla doldurulur.
+"""
+
+import pandas as pd
+import pytest
+
+from symbols import (
+    TROY_ONS_GRAM,
+    VARSAYILAN_KATEGORILER,
+    VarlikEslesme,
+    eslesmeleri_getir,
+    ons_usd_to_gram_try,
+)
+from yahoo import gram_try_serisi, metrikleri_hesapla
+
+
+def _seri(fiyatlar: list[float], baslangic: str = "2026-01-01", gun_araligi: int = 1) -> pd.Series:
+    """Gunluk UTC indeksli kapanis serisi uretir."""
+    indeks = pd.date_range(baslangic, periods=len(fiyatlar), freq=f"{gun_araligi}D", tz="UTC")
+    return pd.Series(fiyatlar, index=indeks)
+
+
+_ESLESME = VarlikEslesme("TEST", "STOCK", "TEST.IS")
+
+
+# ---------------------------------------------------------------------------
+# Ons -> gram cevrimi
+# ---------------------------------------------------------------------------
+
+
+def test_ons_usd_gram_try_cevrimi_dogru_hesaplanir():
+    # 4458.10 USD/ons, 47.8960 USD/TRY -> (4458.10/31.1034768)*47.8960
+    sonuc = ons_usd_to_gram_try(4458.10, 47.8960)
+
+    beklenen = (4458.10 / TROY_ONS_GRAM) * 47.8960
+    assert sonuc == pytest.approx(beklenen)
+    assert sonuc == pytest.approx(6864.4, abs=1.0)  # ~6864 TL/gram
+
+
+def test_ons_cevrimi_gecersiz_girdide_hata_verir():
+    with pytest.raises(ValueError):
+        ons_usd_to_gram_try(0, 47.0)
+    with pytest.raises(ValueError):
+        ons_usd_to_gram_try(4000.0, -1)
+
+
+# ---------------------------------------------------------------------------
+# Metrikler
+# ---------------------------------------------------------------------------
+
+
+def test_gunluk_degisim_son_iki_kapanistan_hesaplanir():
+    veri = metrikleri_hesapla(_ESLESME, _seri([100.0, 110.0]))
+
+    assert veri.current_price == 110.0
+    assert veri.prev_close == 100.0
+    assert veri.daily_change_pct == 10.0
+
+
+def test_prev_close_ile_gunluk_degisim_sema_bagini_korur():
+    """Sema: prev_close = current_price / (1 + daily_change_pct/100)."""
+    veri = metrikleri_hesapla(_ESLESME, _seri([80.0, 92.0]))
+
+    yeniden = veri.current_price / (1 + veri.daily_change_pct / 100)
+    assert yeniden == pytest.approx(veri.prev_close, rel=1e-4)
+
+
+def test_haftalik_degisim_takvim_gunune_gore_hesaplanir():
+    """8 gunluk seride 7 takvim gunu oncesi ILK elemandir."""
+    veri = metrikleri_hesapla(_ESLESME, _seri([100.0, 101, 102, 103, 104, 105, 106, 200.0]))
+
+    # son = 200, 7 gun oncesi = 100 -> %100 artis
+    assert veri.weekly_change_pct == 100.0
+
+
+def test_hafta_sonu_bosluklari_yanlis_referans_secmez():
+    """Islem gunleri seyrek olsa bile referans TAKVIM tarihinden secilir.
+
+    3 gunde bir islem goren bir seride "7 satir geriye" gitmek 21 gun
+    oncesine giderdi; dogru davranis 7 gun veya oncesindeki EN YAKIN
+    kapanisi almaktir.
+    """
+    seri = _seri([10.0, 20.0, 30.0, 40.0], gun_araligi=3)  # 1, 4, 7, 10 Ocak
+
+    veri = metrikleri_hesapla(_ESLESME, seri)
+
+    # Son tarih 10 Ocak; 7 gun oncesi 3 Ocak -> o tarihte veya oncesinde
+    # en yakin kapanis 1 Ocak'taki 10.0
+    assert veri.weekly_change_pct == pytest.approx(300.0)
+
+
+def test_seri_yeterince_geriye_gitmiyorsa_none_doner():
+    """Bir yillik veri yoksa yillik degisim UYDURULMAZ."""
+    veri = metrikleri_hesapla(_ESLESME, _seri([100.0, 105.0, 110.0]))
+
+    assert veri.yearly_change_pct is None
+
+
+def test_tam_bir_yillik_seri_yillik_degisim_URETEMEZ():
+    """`--period 1y` tuzagi: seri tam 365 gun once BASLIYORSA referans yoktur.
+
+    365 gun oncesi serinin ilk gununden ONCEsine dusuyorsa 'onceki veya
+    esit' kayit bulunamaz. Bu yuzden varsayilan period 2y'dir.
+    """
+    seri = _seri([100.0 + i for i in range(365)])  # 1 Ocak'tan itibaren 365 gun
+
+    veri = metrikleri_hesapla(_ESLESME, seri)
+
+    assert veri.yearly_change_pct is None
+
+
+def test_bir_yildan_uzun_seride_yillik_degisim_hesaplanir():
+    seri = _seri([100.0] * 400)
+    seri.iloc[-1] = 150.0  # son gun 150
+
+    veri = metrikleri_hesapla(_ESLESME, seri)
+
+    assert veri.yearly_change_pct == pytest.approx(50.0)
+
+
+def test_gecmis_listesi_price_history_icin_hazir_doner():
+    veri = metrikleri_hesapla(_ESLESME, _seri([100.0, 101.0, 102.0]))
+
+    assert len(veri.gecmis) == 3
+    ts, fiyat = veri.gecmis[-1]
+    assert fiyat == 102.0
+    assert ts.tzinfo is not None  # TIMESTAMPTZ icin zaman dilimi zorunlu
+
+
+def test_volatilite_gunluk_getiri_sapmasi_olarak_hesaplanir():
+    seri = _seri([100, 102, 101, 103, 105, 104, 106, 108])
+
+    veri = metrikleri_hesapla(_ESLESME, seri)
+
+    assert veri.volatilite is not None
+    assert 0 < veri.volatilite < 0.1  # gunluk oynaklik makul aralikta
+
+
+def test_cok_kisa_seride_volatilite_none_doner():
+    veri = metrikleri_hesapla(_ESLESME, _seri([100.0, 101.0]))
+
+    assert veri.volatilite is None
+
+
+# ---------------------------------------------------------------------------
+# Gram altin turetmesi
+# ---------------------------------------------------------------------------
+
+
+def test_gram_serisi_kur_ile_carpilir():
+    altin = _seri([3110.34768, 3110.34768])  # /31.1034768 = tam 100 USD/gram
+    kur = _seri([40.0, 50.0])
+
+    gram = gram_try_serisi(altin, kur)
+
+    assert gram.iloc[0] == pytest.approx(4000.0)
+    assert gram.iloc[1] == pytest.approx(5000.0)
+
+
+def test_kur_eksik_gunde_onceki_kur_kullanilir():
+    """Altin islem gorup kur serisinde o gun veri yoksa son bilinen kur alinir."""
+    altin = _seri([3110.34768, 3110.34768, 3110.34768])  # 1,2,3 Ocak
+    kur = _seri([40.0])  # yalnizca 1 Ocak
+
+    gram = gram_try_serisi(altin, kur)
+
+    assert len(gram) == 3
+    assert gram.iloc[2] == pytest.approx(4000.0)  # 1 Ocak kuru tasindi
+
+
+def test_kur_serisi_altin_baslangicindan_sonra_basliyorsa_bos_gunler_dusurulur():
+    altin = _seri([3110.34768, 3110.34768], baslangic="2026-01-01")
+    kur = _seri([40.0], baslangic="2026-01-02")
+
+    gram = gram_try_serisi(altin, kur)
+
+    # 1 Ocak icin kur yok -> o gun dusurulur, 2 Ocak kalir
+    assert len(gram) == 1
+
+
+# ---------------------------------------------------------------------------
+# Sembol eslemesi
+# ---------------------------------------------------------------------------
+
+
+def test_varsayilan_kategoriler_kriptoyu_icermez():
+    semboller = {e.db_symbol for e in eslesmeleri_getir()}
+
+    assert "THYAO" in semboller
+    assert "GRAM_ALTIN" in semboller
+    assert "USD/TRY" in semboller
+    assert "BTC" not in semboller  # gorev kapsami disinda
+    assert "CRYPTO" not in VARSAYILAN_KATEGORILER
+
+
+def test_kategori_filtresi_calisir():
+    semboller = {e.db_symbol for e in eslesmeleri_getir(["GOLD"])}
+
+    assert semboller == {"GRAM_ALTIN", "GUMUS"}
+
+
+def test_altin_eslesmeleri_turetilmis_isaretlidir():
+    altin = next(e for e in eslesmeleri_getir(["GOLD"]) if e.db_symbol == "GRAM_ALTIN")
+
+    assert altin.turetilmis is True
+    assert altin.yahoo_ticker == "GC=F"
+
+
+def test_bist_hisseleri_is_ekiyle_eslenir():
+    hisseler = eslesmeleri_getir(["STOCK"])
+
+    assert all(e.yahoo_ticker.endswith(".IS") for e in hisseler)
+    assert all(not e.turetilmis for e in hisseler)

--- a/borsa-verisi/tests/test_veritabani.py
+++ b/borsa-verisi/tests/test_veritabani.py
@@ -1,0 +1,312 @@
+"""Veritabani katmaninin AG/DB gerektirmeyen kisimlari.
+
+Gercek yazma testi icin ayakta bir PostgreSQL gerekir; burada yalnizca saf
+mantik (baglanti adresi cozumleme ve SQL sozlesmesi) sabitlenir.
+"""
+
+import psycopg
+
+import database
+from database import VARSAYILAN_DSN, dsn_getir
+
+
+# ---------------------------------------------------------------------------
+# Baglanti adresi cozumleme
+# ---------------------------------------------------------------------------
+
+
+def test_sqlalchemy_surucu_eki_temizlenir():
+    """`.env` SQLAlchemy bicimi tutar; psycopg bu eki anlamaz."""
+    sonuc = dsn_getir("postgresql+psycopg://finans:finans@localhost:5432/finans")
+
+    assert sonuc == "postgresql://finans:finans@localhost:5432/finans"
+
+
+def test_asyncpg_eki_de_temizlenir():
+    assert dsn_getir("postgresql+asyncpg://a:b@h:5432/d") == "postgresql://a:b@h:5432/d"
+
+
+def test_duz_postgresql_adresi_degismez():
+    adres = "postgresql://finans:finans@localhost:5432/finans"
+
+    assert dsn_getir(adres) == adres
+
+
+def test_parametre_yoksa_ortam_degiskeni_kullanilir(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://x:y@db:5432/test")
+
+    assert dsn_getir() == "postgresql://x:y@db:5432/test"
+
+
+def test_hicbir_kaynak_yoksa_varsayilan_kullanilir(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    assert dsn_getir() == VARSAYILAN_DSN
+
+
+def test_bosluklar_kirpilir(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "  postgresql://a:b@h:5432/d  ")
+
+    assert dsn_getir() == "postgresql://a:b@h:5432/d"
+
+
+# ---------------------------------------------------------------------------
+# SQL sozlesmesi - yanlislikla baska tabloya yazmayi engeller
+# ---------------------------------------------------------------------------
+
+
+def test_yalnizca_bolum2_tablolarina_yazilir():
+    """Betik portfoy/sohbet/RAG tablolarina ASLA dokunmamalidir."""
+    tum_sql = " ".join(
+        [
+            database._ASSETS_UPDATE,
+            database._ASSETS_UPDATE_VOLATILITE,
+            database._PRICE_HISTORY_INSERT,
+            database._API_USAGE_UPSERT,
+        ]
+    ).lower()
+
+    for yasak in ("portfolio", "chat_", "users", "rag.", "transactions", "watchlist"):
+        assert yasak not in tum_sql, f"Kapsam disi tabloya dokunuluyor: {yasak}"
+
+
+def test_assets_guncellemesi_kimlik_sutunlarina_dokunmaz():
+    """symbol/name/category_id/currency DEGISTIRILMEMELIDIR."""
+    sql = database._ASSETS_UPDATE.lower()
+    govde = sql.split("where")[0]
+
+    for korunan in ("category_id", "currency =", "name ="):
+        assert korunan not in govde
+
+
+def test_price_history_kaynagi_api_olarak_isaretlenir():
+    """Simulatorun urettigi satirlardan ayirt edilebilmeli."""
+    assert "'api'" in database._PRICE_HISTORY_INSERT
+
+
+def test_price_history_ayni_zaman_damgasinda_cakismaz():
+    """PRIMARY KEY (asset_id, ts) - tekrar calistirma hata vermemeli."""
+    assert "on conflict (asset_id, ts) do update" in database._PRICE_HISTORY_INSERT.lower()
+
+
+def test_api_kullanimi_sayaci_uzerine_yazmaz_ekler():
+    """Ayni gun ikinci kez calistirilirsa sayac SIFIRLANMAMALI."""
+    assert "call_count + excluded.call_count" in database._API_USAGE_UPSERT.lower()
+
+
+def test_sql_ifadeleri_gecerli_sekilde_ayristirilir():
+    """psycopg parametre yer tutucularini cozebiliyor mu?"""
+    for sql in (database._PRICE_HISTORY_INSERT, database._API_USAGE_UPSERT):
+        # psycopg client-side ayristirici; sozdizimi bozuksa burada patlar.
+        psycopg.sql.SQL(sql)  # noqa: B018
+
+
+# ---------------------------------------------------------------------------
+# Yazma davranisi - sahte baglanti ile
+# ---------------------------------------------------------------------------
+
+
+class SahteCursor:
+    """Sahte imlec. Varsayilan olarak TAM semali bir veritabani taklit eder."""
+
+    def __init__(self, harita, kolonlar=None):
+        self.harita = harita
+        self.kolonlar = _TAM_SEMA if kolonlar is None else kolonlar
+        self.calistirilan = []
+        self.rowcount = 1
+        self._sonuc = []
+
+    def execute(self, sql, params=None):
+        self.calistirilan.append((sql, params))
+        if "SELECT symbol, id FROM assets" in sql:
+            self._sonuc = list(self.harita.items())
+        elif "information_schema.columns" in sql:
+            self._sonuc = [(k,) for k in self.kolonlar]
+        return self
+
+    def executemany(self, sql, params):
+        self.calistirilan.append((sql, params))
+
+    def fetchall(self):
+        return self._sonuc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class SahteConnection:
+    def __init__(self, harita, kolonlar=None):
+        self._cursor = SahteCursor(harita, kolonlar)
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_veritabaninda_olmayan_sembol_atlanir_ve_raporlanir():
+    """Bilinmeyen sembol icin YENI VARLIK YARATILMAZ."""
+    from yahoo import PiyasaVerisi
+
+    conn = SahteConnection({"THYAO": 1})
+    veriler = [
+        PiyasaVerisi("THYAO", "STOCK", "THYAO.IS", current_price=300.0),
+        PiyasaVerisi("YOKBOYLE", "STOCK", "YOK.IS", current_price=10.0),
+    ]
+
+    sonuc = database.varliklari_yaz(conn, veriler, gecmis_yaz=False)
+
+    assert sonuc.bulunamayan_semboller == ["YOKBOYLE"]
+    calistirilan_sql = " ".join(s for s, _ in conn._cursor.calistirilan)
+    assert "INSERT INTO assets" not in calistirilan_sql
+
+
+def test_gecmis_yaz_kapaliyken_price_history_yazilmaz():
+    from yahoo import PiyasaVerisi
+
+    conn = SahteConnection({"THYAO": 1})
+    veri = PiyasaVerisi("THYAO", "STOCK", "THYAO.IS", current_price=300.0, gecmis=[(None, 1.0)])
+
+    sonuc = database.varliklari_yaz(conn, [veri], gecmis_yaz=False)
+
+    assert sonuc.yazilan_gecmis == 0
+
+
+def test_volatilite_varsayilan_olarak_guncellenmez():
+    """sim_volatility simulator ayaridir; istenmedikce DOKUNULMAZ."""
+    from yahoo import PiyasaVerisi
+
+    conn = SahteConnection({"THYAO": 1})
+    veri = PiyasaVerisi("THYAO", "STOCK", "THYAO.IS", current_price=300.0, volatilite=0.02)
+
+    database.varliklari_yaz(conn, [veri], gecmis_yaz=False, volatilite_guncelle=False)
+
+    guncelleme_sql = [s for s, _ in conn._cursor.calistirilan if "UPDATE assets" in s]
+    assert guncelleme_sql
+    assert "sim_volatility" not in guncelleme_sql[0]
+
+
+def test_volatilite_acikca_istenirse_guncellenir():
+    from yahoo import PiyasaVerisi
+
+    conn = SahteConnection({"THYAO": 1})
+    veri = PiyasaVerisi("THYAO", "STOCK", "THYAO.IS", current_price=300.0, volatilite=0.02)
+
+    database.varliklari_yaz(conn, [veri], gecmis_yaz=False, volatilite_guncelle=True)
+
+    guncelleme_sql = [s for s, _ in conn._cursor.calistirilan if "UPDATE assets" in s]
+    assert "sim_volatility" in guncelleme_sql[0]
+
+
+def test_eksik_semali_veritabaninda_yazma_yine_calisir():
+    """Supabase senaryosu: 3 kolon eksik ama fiyat yazimi TAMAMLANMALI."""
+    from yahoo import PiyasaVerisi
+
+    conn = SahteConnection({"THYAO": 1}, kolonlar=_EKSIK_SEMA)
+    veri = PiyasaVerisi(
+        "THYAO", "STOCK", "THYAO.IS", current_price=301.5, prev_close=300.0, daily_change_pct=0.5
+    )
+
+    sonuc = database.varliklari_yaz(conn, [veri], gecmis_yaz=False)
+
+    assert sonuc.guncellenen_varlik == 1
+    assert sonuc.atlanan_kolonlar == ["prev_close", "price_updated_at", "sim_volatility"]
+
+
+def test_sifir_cagride_kullanim_kaydi_yazilmaz():
+    conn = SahteConnection({})
+
+    database.api_kullanimi_kaydet(conn, 0)
+
+    assert conn._cursor.calistirilan == []
+
+
+# ---------------------------------------------------------------------------
+# Semaya uyum - eksik kolonlar tum yazmayi dusurmemeli
+# ---------------------------------------------------------------------------
+
+
+_TAM_SEMA = {
+    "current_price",
+    "prev_close",
+    "daily_change_pct",
+    "weekly_change_pct",
+    "yearly_change_pct",
+    "price_updated_at",
+    "sim_volatility",
+}
+
+#: Supabase'deki gercek sema - 3 kolon eksik.
+_EKSIK_SEMA = {
+    "current_price",
+    "daily_change_pct",
+    "weekly_change_pct",
+    "yearly_change_pct",
+}
+
+
+def test_tam_semada_tum_kolonlar_yazilir():
+    sorgu = database.assets_update_sorgusu(_TAM_SEMA)
+
+    assert "prev_close" in sorgu
+    assert "price_updated_at" in sorgu
+    assert "current_price" in sorgu
+
+
+def test_eksik_kolonlar_sorgudan_cikarilir():
+    """prev_close/price_updated_at yoksa SQL onlari HIC icermemeli."""
+    sorgu = database.assets_update_sorgusu(_EKSIK_SEMA)
+
+    assert "prev_close" not in sorgu
+    assert "price_updated_at" not in sorgu
+    # Cekirdek alanlar yine yazilir
+    assert "current_price" in sorgu
+    assert "daily_change_pct" in sorgu
+    assert "yearly_change_pct" in sorgu
+
+
+def test_eksik_semada_sorgu_gecerli_sql_kalir():
+    """Kolon atlaninca fazladan virgul kalmamali."""
+    sorgu = database.assets_update_sorgusu(_EKSIK_SEMA)
+
+    assert ",\nWHERE" not in sorgu
+    assert sorgu.strip().endswith("WHERE symbol = %(symbol)s")
+    psycopg.sql.SQL(sorgu)  # noqa: B018 - sozdizimi bozuksa patlar
+
+
+def test_volatilite_kolonu_yoksa_istense_bile_yazilmaz():
+    sorgu = database.assets_update_sorgusu(_EKSIK_SEMA, volatilite_guncelle=True)
+
+    assert "sim_volatility" not in sorgu
+
+
+def test_volatilite_kolonu_varsa_ve_istenirse_yazilir():
+    sorgu = database.assets_update_sorgusu(_TAM_SEMA, volatilite_guncelle=True)
+
+    assert "sim_volatility" in sorgu
+
+
+def test_market_api_usage_tablosu_yoksa_atlanir(monkeypatch):
+    """Sayac tablosu yoksa fiyat yazimi RISKE ATILMAZ.
+
+    PostgreSQL'de basarisiz bir ifade tum islemi iptal eder; sayac ugruna
+    6.500 satirlik fiyat verisi geri alinmamalidir.
+    """
+    monkeypatch.setattr(database, "tablo_var_mi", lambda conn, tablo: False)
+    conn = SahteConnection({})
+
+    database.api_kullanimi_kaydet(conn, 14)
+
+    yazma_sql = [s for s, _ in conn._cursor.calistirilan if "market_api_usage" in s]
+    assert yazma_sql == []
+
+
+def test_market_api_usage_tablosu_varsa_yazilir(monkeypatch):
+    monkeypatch.setattr(database, "tablo_var_mi", lambda conn, tablo: True)
+    conn = SahteConnection({})
+
+    database.api_kullanimi_kaydet(conn, 14)
+
+    yazma_sql = [s for s, _ in conn._cursor.calistirilan if "market_api_usage" in s]
+    assert len(yazma_sql) == 1

--- a/borsa-verisi/tests/test_veritabani.py
+++ b/borsa-verisi/tests/test_veritabani.py
@@ -9,7 +9,6 @@ import psycopg
 import database
 from database import VARSAYILAN_DSN, dsn_getir
 
-
 # ---------------------------------------------------------------------------
 # Baglanti adresi cozumleme
 # ---------------------------------------------------------------------------

--- a/borsa-verisi/yahoo.py
+++ b/borsa-verisi/yahoo.py
@@ -1,0 +1,261 @@
+"""Yahoo Finance'ten fiyat cekme ve `assets` metriklerini hesaplama.
+
+Bu katman VERITABANINI BILMEZ - yalnizca Yahoo'dan seri ceker ve semanin
+istedigi metrikleri uretir. Yazma isi `database.py` sorumlulugundadir.
+
+METRIKLERIN SEMA ILE ILISKISI (db/v5_schema_and_data.sql bolum 2)
+    current_price      -> serinin son kapanisi
+    prev_close         -> bir onceki kapanis
+    daily_change_pct   -> (current / prev_close - 1) * 100
+    weekly_change_pct  -> 7 takvim gunu oncesine gore degisim
+    yearly_change_pct  -> 365 takvim gunu oncesine gore degisim
+    price_updated_at   -> yazma aninda now()
+
+    Semadaki `prev_close = current_price / (1 + daily_change_pct/100)` bagi
+    KORUNUR: iki deger de ayni seriden turedigi icin tutarlidir.
+
+TAKVIM GUNU vs ISLEM GUNU
+    Borsa hafta sonu ve tatilde kapalidir; "7 satir geriye git" demek yanlis
+    sonuc verir. Bu yuzden haftalik/yillik degisim TAKVIM tarihine gore, o
+    tarihteki veya ONCESINDEKI en yakin islem gunu kapanisiyla hesaplanir.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+import pandas as pd
+import yfinance as yf
+
+from symbols import (
+    TROY_ONS_GRAM,
+    TURETME_ONS_USD_GRAM_TRY,
+    USDTRY_TICKER,
+    VarlikEslesme,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Yahoo'yu yormamak icin cagrilar arasi bekleme (saniye). yfinance resmi bir
+#: API degildir; art arda hizli istek atmak gecici engellemeye yol acabilir.
+CAGRI_ARASI_BEKLEME = 0.4
+
+#: Oynaklik (volatilite) hesabinda kullanilan son islem gunu sayisi.
+#: `assets.sim_volatility` simulatorde tek adimlik sigma olarak kullanildigi
+#: icin GUNLUK getiri standart sapmasi hesaplanir.
+VOLATILITE_PENCERE = 90
+
+
+@dataclass
+class PiyasaVerisi:
+    """Tek bir varligin Yahoo'dan uretilmis tam kaydi."""
+
+    db_symbol: str
+    kategori: str
+    kaynak_ticker: str
+    current_price: float
+    prev_close: float | None = None
+    daily_change_pct: float | None = None
+    weekly_change_pct: float | None = None
+    yearly_change_pct: float | None = None
+    volatilite: float | None = None
+    turetilmis: bool = False
+    #: `price_history` icin (UTC zaman damgasi, fiyat) ikilileri.
+    gecmis: list[tuple[datetime, float]] = field(default_factory=list)
+
+
+@dataclass
+class ToplamaSonucu:
+    """Bir toplama turunun ciktisi."""
+
+    veriler: list[PiyasaVerisi] = field(default_factory=list)
+    hatalar: list[tuple[str, str]] = field(default_factory=list)
+    cagri_sayisi: int = 0
+
+
+class YahooHatasi(RuntimeError):
+    """Yahoo'dan kullanilabilir veri alinamadi."""
+
+
+# ---------------------------------------------------------------------------
+# Seri getirme
+# ---------------------------------------------------------------------------
+
+
+def _utc_indeksle(df: pd.DataFrame) -> pd.DataFrame:
+    """DataFrame indeksini UTC'ye normalize eder.
+
+    yfinance ticker'a gore bazen zaman dilimi bilgili (BIST icin
+    Europe/Istanbul), bazen bilgisiz indeks doner. Farkli varliklari
+    hizalayabilmek icin hepsi UTC'ye cevrilir.
+    """
+    indeks = pd.DatetimeIndex(df.index)
+    if indeks.tz is None:
+        indeks = indeks.tz_localize("UTC")
+    else:
+        indeks = indeks.tz_convert("UTC")
+    df = df.copy()
+    df.index = indeks
+    return df.sort_index()
+
+
+def kapanis_serisi(ticker: str, period: str = "1y") -> pd.Series:
+    """Bir ticker icin gunluk kapanis serisi ceker.
+
+    Raises:
+        YahooHatasi: Yahoo bos sonuc dondururse (gecersiz sembol, ag hatasi
+            veya gecici engelleme).
+    """
+    ham = yf.Ticker(ticker).history(period=period, interval="1d", auto_adjust=False)
+
+    if ham is None or ham.empty or "Close" not in ham:
+        raise YahooHatasi(f"'{ticker}' icin Yahoo bos veri dondurdu.")
+
+    seri = _utc_indeksle(ham)["Close"].dropna()
+    seri = seri[seri > 0]
+
+    if seri.empty:
+        raise YahooHatasi(f"'{ticker}' icin gecerli kapanis fiyati yok.")
+
+    return seri
+
+
+# ---------------------------------------------------------------------------
+# Metrik hesaplama
+# ---------------------------------------------------------------------------
+
+
+def _gecmis_deger(seri: pd.Series, gun_once: int) -> float | None:
+    """`gun_once` takvim gunu onceki (veya ondan ONCEKI en yakin) kapanis.
+
+    Seri o tarihe kadar geriye gitmiyorsa `None` doner - uydurma yapilmaz.
+    """
+    hedef = seri.index[-1] - timedelta(days=gun_once)
+    oncekiler = seri[seri.index <= hedef]
+    if oncekiler.empty:
+        return None
+    return float(oncekiler.iloc[-1])
+
+
+def _degisim_yuzdesi(guncel: float, referans: float | None) -> float | None:
+    """Yuzde degisim; referans yoksa veya sifirsa `None`."""
+    if referans is None or referans <= 0:
+        return None
+    return round((guncel / referans - 1) * 100, 2)
+
+
+def _volatilite(seri: pd.Series) -> float | None:
+    """Gunluk getirilerin standart sapmasi (`sim_volatility` karsiligi)."""
+    getiriler = seri.tail(VOLATILITE_PENCERE).pct_change().dropna()
+    if len(getiriler) < 5:
+        return None
+    return round(float(getiriler.std()), 6)
+
+
+def metrikleri_hesapla(
+    eslesme: VarlikEslesme, seri: pd.Series, turetilmis: bool = False
+) -> PiyasaVerisi:
+    """Kapanis serisinden semanin bekledigi tum alanlari uretir."""
+    guncel = float(seri.iloc[-1])
+    onceki = float(seri.iloc[-2]) if len(seri) >= 2 else None
+
+    return PiyasaVerisi(
+        db_symbol=eslesme.db_symbol,
+        kategori=eslesme.kategori,
+        kaynak_ticker=eslesme.yahoo_ticker,
+        current_price=round(guncel, 4),
+        prev_close=round(onceki, 4) if onceki else None,
+        daily_change_pct=_degisim_yuzdesi(guncel, onceki),
+        weekly_change_pct=_degisim_yuzdesi(guncel, _gecmis_deger(seri, 7)),
+        yearly_change_pct=_degisim_yuzdesi(guncel, _gecmis_deger(seri, 365)),
+        volatilite=_volatilite(seri),
+        turetilmis=turetilmis,
+        gecmis=[(ts.to_pydatetime(), round(float(fiyat), 4)) for ts, fiyat in seri.items()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Turetme: ons/USD -> gram/TRY
+# ---------------------------------------------------------------------------
+
+
+def gram_try_serisi(ons_usd: pd.Series, usdtry: pd.Series) -> pd.Series:
+    """Ons/USD serisini gram/TRY serisine cevirir.
+
+    Iki seri farkli gunlerde islem gorebilir (vadeli piyasa Pazar aksami
+    acilir, doviz neredeyse kesintisizdir). Bu yuzden kur serisi altin
+    tarihlerine hizalanir ve bosluklar bir onceki gecerli kurla doldurulur
+    (`ffill`) - kur uydurulmaz, en son bilinen deger kullanilir.
+    """
+    altin = ons_usd.copy()
+    kur = usdtry.copy()
+    altin.index = pd.DatetimeIndex(altin.index).normalize()
+    kur.index = pd.DatetimeIndex(kur.index).normalize()
+
+    altin = altin[~altin.index.duplicated(keep="last")].sort_index()
+    kur = kur[~kur.index.duplicated(keep="last")].sort_index()
+
+    hizali_kur = kur.reindex(altin.index, method="ffill")
+    gram = (altin / TROY_ONS_GRAM) * hizali_kur
+    return gram.dropna()
+
+
+# ---------------------------------------------------------------------------
+# Toplama
+# ---------------------------------------------------------------------------
+
+
+def varliklari_topla(
+    eslesmeler: list[VarlikEslesme], period: str = "1y", bekleme: float = CAGRI_ARASI_BEKLEME
+) -> ToplamaSonucu:
+    """Verilen eslesmeler icin Yahoo'dan veri ceker.
+
+    Bir varlik cekilemezse akis DURMAZ: hata listeye yazilir ve digerlerine
+    devam edilir (kismi basari). Boylece tek bir sembolun bozulmasi tum
+    toplamayi dusurmez.
+    """
+    sonuc = ToplamaSonucu()
+    usdtry_seri: pd.Series | None = None
+
+    # Turetilmis varlik varsa kur serisi BIR KEZ cekilir ve yeniden kullanilir.
+    turetme_var = any(e.turetilmis for e in eslesmeler)
+    if turetme_var:
+        try:
+            usdtry_seri = kapanis_serisi(USDTRY_TICKER, period)
+            sonuc.cagri_sayisi += 1
+            logger.info("USD/TRY kur serisi alindi (turetme icin)")
+        except YahooHatasi as exc:
+            sonuc.hatalar.append((USDTRY_TICKER, f"Turetme kuru alinamadi: {exc}"))
+
+    for eslesme in eslesmeler:
+        try:
+            seri = kapanis_serisi(eslesme.yahoo_ticker, period)
+            sonuc.cagri_sayisi += 1
+
+            if eslesme.turetme == TURETME_ONS_USD_GRAM_TRY:
+                if usdtry_seri is None:
+                    raise YahooHatasi("USD/TRY kuru olmadan gram fiyati hesaplanamaz.")
+                seri = gram_try_serisi(seri, usdtry_seri)
+                if seri.empty:
+                    raise YahooHatasi("Turetme sonrasi ortak tarih kalmadi.")
+
+            sonuc.veriler.append(metrikleri_hesapla(eslesme, seri, turetilmis=eslesme.turetilmis))
+            logger.info(
+                "veri alindi",
+                extra={"sembol": eslesme.db_symbol, "ticker": eslesme.yahoo_ticker},
+            )
+
+        except Exception as exc:  # noqa: BLE001 - tek varlik toplamayi dusurmemeli
+            sonuc.hatalar.append((eslesme.db_symbol, str(exc)))
+            logger.warning(
+                "veri alinamadi",
+                extra={"sembol": eslesme.db_symbol, "hata": str(exc)},
+            )
+
+        if bekleme:
+            time.sleep(bekleme)
+
+    return sonuc

--- a/db/migrations/001_assets_fiyat_kolonlari.sql
+++ b/db/migrations/001_assets_fiyat_kolonlari.sql
@@ -1,0 +1,63 @@
+-- =====================================================================
+-- 001 - assets tablosundaki fiyat kolonlarini tamamlar
+-- =====================================================================
+--
+-- NEDEN GEREKLI
+--   `db/v5_schema_and_data.sql` sifirdan kurulan bir veritabaninda bu uc
+--   kolonu zaten yaratir. Ancak ekibin PAYLASILAN Supabase veritabani daha
+--   eski bir semadan turedi ve 16 Agustos 2026'da bu kolonlar orada YOKTU.
+--
+--   Backend'in fiyat gorevi bu kolonlari opsiyonel saymaz, dogrudan kullanir:
+--     * app/repositories/sql.py -> get_prices_for_simulation()  : sim_volatility
+--     * app/repositories/sql.py -> apply_price_updates()        : prev_close,
+--                                                                 price_updated_at
+--   Kolonlar eksikse sorgular "UndefinedColumn" ile patlar. Hata
+--   `run_price_scheduler` icinde yakalanip loglandigi icin uygulama AYAKTA
+--   KALIR ama fiyatlar hic guncellenmez - yani ariza SESSIZDIR.
+--
+-- CALISTIRMA
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/migrations/001_assets_fiyat_kolonlari.sql
+--
+-- GUVENLIK
+--   Tamamen idempotenttir: kolonlar zaten varsa hicbir sey yapmaz, veri
+--   silmez, mevcut degerleri EZMEZ. Iki kez calistirmak zararsizdir.
+-- =====================================================================
+
+BEGIN;
+
+-- 1) Eksik kolonlari ekle -------------------------------------------------
+--    NOT NULL DEFAULT ile eklemek mevcut satirlari da doldurur; sim_volatility
+--    simulatorun adim buyuklugudur ve NULL kalirsa saglayici 0.015'e duser.
+ALTER TABLE assets ADD COLUMN IF NOT EXISTS prev_close       NUMERIC;
+ALTER TABLE assets ADD COLUMN IF NOT EXISTS price_updated_at TIMESTAMPTZ;
+ALTER TABLE assets ADD COLUMN IF NOT EXISTS sim_volatility   NUMERIC NOT NULL DEFAULT 0.0150;
+
+-- 2) Yeni eklenen kolonlari makul baslangic degerleriyle doldur -----------
+--    prev_close bos kalirsa daily_change_pct hesabi (bkz. apply_price_updates)
+--    ilk tick'te calismaz. Mevcut fiyat ve gunluk degisimden geriye donuk
+--    turetiyoruz - v5_schema_and_data.sql ile AYNI formul.
+UPDATE assets
+   SET prev_close = ROUND(current_price / (1 + COALESCE(daily_change_pct, 0) / 100.0), 4)
+ WHERE prev_close IS NULL
+   AND current_price IS NOT NULL;
+
+UPDATE assets
+   SET price_updated_at = now()
+ WHERE price_updated_at IS NULL;
+
+-- 3) Kota sayaci tablosu --------------------------------------------------
+--    `market_api_usage` da eski semalarda olmayabilir. Backend bu tabloyu
+--    gunluk Yahoo istek tavani icin kullanir; yoksa tavan devre disi kalir.
+CREATE TABLE IF NOT EXISTS market_api_usage (
+    usage_date   DATE PRIMARY KEY,
+    call_count   INT NOT NULL DEFAULT 0,
+    last_call_at TIMESTAMPTZ
+);
+
+COMMIT;
+
+-- Dogrulama (elle calistirin, bu betigin parcasi degildir):
+--   SELECT column_name FROM information_schema.columns
+--    WHERE table_schema = 'public' AND table_name = 'assets'
+--      AND column_name IN ('prev_close','price_updated_at','sim_volatility');
+--   -> uc satir donmelidir.

--- a/db/v5_schema_and_data.sql
+++ b/db/v5_schema_and_data.sql
@@ -381,6 +381,13 @@ INSERT INTO assets (category_id, symbol, name, currency, current_price,
 (2,'GUMUS','Gram Gümüş','TRY',31.50,-0.2,1.1,42.6,0.0120),
 (3,'USD/TRY','Amerikan Doları','TRY',33.55,0.1,0.8,25.4,0.0050),
 (3,'EUR/TRY','Euro','TRY',36.80,0.3,1.2,28.7,0.0050),
+-- TR10Y (id 11): Yahoo Finance'te güvenilir bir karşılığı YOKTUR, bu yüzden
+-- ekibin paylaşılan veritabanından 16 Ağustos 2026'da silindi
+-- (bkz. borsa-verisi/symbols.py). Burada BİLEREK duruyor: satır silinirse
+-- SERIAL id'ler kayar (BTC 12->11) ve aşağıdaki transactions/watchlist
+-- kayıtları sessizce YANLIŞ varlığa bağlanır. Şema sıfırdan yüklenirse TR10Y
+-- geri gelir ve gerçek fiyat kaynağı olmadığı için yalnızca simüle fiyat
+-- alır - price_history.source o satırlarda 'simulated' yazar.
 (4,'TR10Y','Türkiye 10 Yıllık Tahvil','TRY',100.00,0.0,0.0,15.5,0.0020),
 (5,'BTC','Bitcoin','USD',65400.00,4.5,-2.3,125.6,0.0400),
 (5,'ETH','Ethereum','USD',3450.00,2.1,-1.5,85.2,0.0450),


### PR DESCRIPTION
Iki parcali is: (1) veritabanini gercek gecmis veriyle bir kereligine doldurma, (2) backend'in canli fiyat kaynagini simulasyondan gercek Yahoo Finance verisine baglama.

## 1) borsa-verisi/ — tek seferlik gecmis veri toplama betigi

Yeni, bagimsiz klasor. `assets` ve `price_history` tablolarini gercek Yahoo Finance verisiyle doldurur:

- symbols.py    : assets.symbol -> Yahoo ticker eslemesi (13 varlik +
                  3 kripto opsiyonel); gram altin/gumus ons USD'den
                  turetilir (Yahoo'da TRY/gram sembolu yok)
- yahoo.py       : kapanis serisi cekme + metrik hesabi (gunluk/haftalik/
                  yillik degisim TAKVIM gunune gore, islem gunu degil)
- database.py    : PostgreSQL yazma katmani; sema kolonlari calisma
                  aninda kontrol edilir (Supabase'deki gercek semada
                  prev_close/price_updated_at/sim_volatility yoktu,
                  betik bunlari sessizce atlar)
- collect.py     : CLI. --kuru-calistir ile once hicbir sey yazmadan
                  onizleme yapilir

Sonuc: assets + price_history 2 yillik gercek veriyle dolduruldu (16 varlik, TR10Y Yahoo'da guvenilir karsiligi olmadigi icin veritabanindan kaldirildi). 44 test (ag/DB gerektirmez).

## 2) Backend — canli fiyat kaynagi gercek Yahoo Finance'e baglandi

`ApiMarketProvider` daha once dogrudan simulatore duserdi ("HENUZ BAGLANMADI"). Artik gercekten Yahoo'dan fiyat cekiyor:

- app/market/yahoo.py    : YENI. Tum semboller TEK istekte cekilir
                          (yf.download) - gunde ~96 cagri, sembol
                          basina ayri istek olsaydi ~1.500 cagri olurdu
- app/market/provider.py : ApiMarketProvider gercek Yahoo'ya bagli;
                          kota dolarsa/Yahoo hata verirse simulatore
                          duser ve bunu GIZLEMEZ (son_kaynak alani)
- Duzeltilen hata: price_history'ye GERCEK veri gelse bile sabit
  'simulated' yaziliyordu; artik gercekten kullanilan kaynak yazilir
- Duzeltilen hata: market_api_usage tablosu kodda hic kullanilmiyordu;
  kota sayaci artik calisiyor (get/record_api_usage repository'lere
  eklendi, base.py sozlesmesi guncellendi)
- config: MARKET_DATA_PROVIDER varsayilani "api" oldu, tick araligi
  60sn -> 900sn (15dk, Yahoo kotasi icin)
- app/api/routes/market.py: /api/market/history gun siniri 365 -> 730
  (2 yillik veriyi artik servis edebiliyor)
- run.py: YENI. Windows'ta psycopg'nin async surucusu varsayilan
  ProactorEventLoop ile calismiyordu. `uvicorn app.main:app` ile
  duzeltilemedi (uvicorn kendi event loop'unu app modulunu import
  etmeden ONCE kuruyor); run.py policy'yi uvicorn baslamadan once
  ayarlayan bir launcher

Tum degisiklikler gercek Supabase veritabanina karsi ucdan uca dogrulandi (gercek HTTP istegi, gercek Yahoo cagrisi). Backend: 252 test gecti (128'i DB baglantisi gerektirdigi icin bu ortamda atlandi).

## Ne yapıldı

<!-- Kısa açıklama -->

## İlgili gereksinim / görev

<!-- FR-XXX-NN veya backlog maddesi -->

## Nasıl test edildi

<!-- Adımlar veya eklenen testler -->

## Kontrol listesi

- [ ] CI yeşil
- [ ] Yeni env değişkeni varsa `.env.example` güncellendi
- [ ] Gizli bilgi (API key, şifre) commit edilmedi
- [ ] Gerekli dokümantasyon güncellendi
