### PR TITLE
fix: varlık kartı sohbet sızıntısı, alakasız kart temizliği, çoklu varlık desteği + sohbetten al/sat

### DIFF
--- a/backend/app/agents/market_research.py
+++ b/backend/app/agents/market_research.py
@@ -820,6 +820,102 @@ def resolve_symbol(query: str, katalog: list[dict[str, Any]]) -> str | None:
     return en_iyi[2] if en_iyi else None
 
 
+#: `resolve_symbols` en fazla kac EK sembol dondurur (birincil `resolve_symbol`
+#: sonucu HARIC). Toplam kart sayisi sinirinin (`KART_SEMBOL_SINIRI`,
+#: orchestrator.py) 1 eksigi - birincil sembol zaten o siniri paylasiyor.
+_EK_SEMBOL_SINIRI = 2
+
+
+def resolve_symbols(
+    query: str,
+    katalog: list[dict[str, Any]],
+    *,
+    limit: int = _EK_SEMBOL_SINIRI,
+    disla: str | None = None,
+) -> list[str]:
+    """Sorguda gecen BIRDEN FAZLA varligi katalogdan cozer.
+
+    ⚠️ `resolve_symbol`'DEN BILEREK AYRI TUTULUR. O fonksiyon "TEK en iyi
+    aday"i bulmak icin olculerek kalibre edildi (bkz. docstring'i - "thyao
+    hissesi" -> None gibi false-positive avlari, takma ad eslestirme,
+    bitisik-olmayan kod yazimi gibi ince katmanlar). Bu fonksiyon COKLU
+    tespit icin `resolve_symbol`'un EN GUVENILIR IKI katmanini kullanir:
+
+      1. Tam kod eslesmesi ("ASELS")
+      2. Kod + Turkce ek eslesmesi ("aselsan", "eregli" -> EREGL+i) - BU
+         KATMAN ILK SURUMDE BILEREK ATLANMISTI ve GERCEK BIR HATAYA yol
+         actu: "nvidia ve ereğli ne kadar" sorusunda EREGL hic bulunamadi,
+         cunku katalogdaki adi "Erdemir" (Eregli DEGIL) - kod+ek eslesmesi
+         olmadan hicbir yol EREGL'i bulamiyordu. Bu katman `resolve_symbol`'da
+         zaten "aselsan" gibi GUNLUK kullanimin TEMELINI olusturuyor (tier 2,
+         tam eslesmeden hemen sonraki en guvenilir katman) - coklu tespitte
+         de ayni guvenilirlikte.
+      3. Tam sirket adi eslesmesi ("aselsan" ad alaninda gecerse)
+
+    Takma adlar ve sirket adinin "ilk kelimesi" gibi DAHA gevsek katmanlar
+    (resolve_symbol'daki tier 2'nin GEVSEK yarisi) BILEREK ATLANMAYA DEVAM
+    EDER: "bu hisse ne kadar dustu" gibi genel bir ifadeyi ucuncu bir varlik
+    sanmak YANLIS POZITIF uretirdi. `resolve_symbol`'un ana kod yolu HIC
+    DEGISTIRILMEDI - onun olculmus davranisina risk katmamak icin bu
+    fonksiyon tamamen bagimsiz, kendi taramasini yapar.
+
+    Args:
+        limit: azami dondurulecek sembol sayisi (sorgudaki gecis sirasina gore).
+        disla: zaten cozulmus BIRINCIL sembol - sonuc listesinden cikarilir
+            (aksi halde "NVDA ve NVDA" gibi tekrar cikardi).
+
+    Returns:
+        Sorguda GECTIGI SIRAYLA, tekrarsiz, katalogla dogrulanmis semboller.
+        `disla` HARIC en fazla `limit` adet.
+    """
+    metin = _normalize(query)
+    tokenler = re.findall(r"[a-z0-9]+", metin)
+    if not tokenler:
+        return []
+
+    adaylar: list[tuple[int, str]] = []  # (konum, sembol)
+
+    for kayit in katalog:
+        sembol = str(kayit.get("symbol") or "").strip()
+        # Kisa kodlar (KO, T) coklu taramada BILEREK DISLANIR: `resolve_symbol`
+        # bunlari yalnizca HAM sorguda buyuk harfle tam kelime olarak kabul
+        # ediyordu (gunluk kelimelerle cakismasin diye) - o incelikli kontrolu
+        # burada tekrarlamak yerine, coklu tespitte bu kisa kodlari atlamak
+        # tercih edildi: yanlis pozitif riski (KO -> "ko" kelimesi) faydasindan
+        # yuksek.
+        if not sembol or len(sembol) < _ASGARI_SEMBOL_UZUNLUGU:
+            continue
+
+        kok = _normalize(sembol)
+        kok_sikisik = re.sub(r"[^a-z0-9]", "", kok)
+        kokler = {kok, kok_sikisik} - {""}
+
+        eslesti = False
+        for konum, token in enumerate(tokenler):
+            # Tam eslesme YA DA kod+Turkce ek eslesmesi ("eregli" -> EREGL).
+            if token in kokler or any(_matches_with_suffix(token, k) for k in kokler):
+                adaylar.append((konum, sembol.upper()))
+                eslesti = True
+                break
+
+        if eslesti:
+            continue
+
+        ad = _normalize(str(kayit.get("ad") or ""))
+        if ad and ad in metin:
+            adaylar.append((metin.index(ad), sembol.upper()))
+
+    adaylar.sort()
+    sonuc: list[str] = []
+    for _, sembol in adaylar:
+        if sembol == disla or sembol in sonuc:
+            continue
+        sonuc.append(sembol)
+        if len(sonuc) >= limit:
+            break
+    return sonuc
+
+
 # ---------------------------------------------------------------------------
 # Mevsimsellik: "gecmis yillarin yaz aylarinda nasil hareket etti?"
 # ---------------------------------------------------------------------------
@@ -1130,6 +1226,7 @@ class MarketResearchAgent(BaseAgent):
         canli_veri: dict[str, Any] | None = None
         guven: float | None = None
         hatalar: list[AgentError] = []
+        ek_sembol_verileri: list[dict[str, Any]] = []
 
         if mode in ("rag", "both"):
             rag_ozet, kaynaklar, ham_kaynaklar, guven, rag_hatasi = await self._run_rag(task, query)
@@ -1142,6 +1239,16 @@ class MarketResearchAgent(BaseAgent):
             canli_ozet, canli_veri = await self._run_live(task)
             if canli_ozet:
                 ozet_parcalari.append(canli_ozet)
+
+            # COKLU VARLIK: "NVIDIA ve Apple ne durumda" gibi sorularda
+            # birincil sembol (`task["symbol"]`) YANINDA gecen diger
+            # varliklarin da fiyati cekilir - aksi halde model yalnizca
+            # ilkinden bahsedip ikinciyi sessizce yok sayiyordu (canli
+            # bildirildi). Sadece "live"/"both" modda anlamlidir - saf RAG
+            # sorusunda (haber arama) ek varliklarin fiyatini cekmenin
+            # anlami yok.
+            ek_ozet_satirlari, ek_sembol_verileri = await self._ek_sembolleri_getir(task, query)
+            ozet_parcalari.extend(ek_ozet_satirlari)
 
         ozet = "\n\n".join(ozet_parcalari) if ozet_parcalari else NO_RETRIEVAL_MESSAGE
 
@@ -1156,6 +1263,11 @@ class MarketResearchAgent(BaseAgent):
                 # orchestrator bunu "mentioned_assets" SSE olayina tasir, frontend
                 # sohbet cevabinin altinda varlik karti gostermek icin kullanir.
                 "symbol": task.get("symbol"),
+                # Sorguda BIRINCIL sembolun yaninda gecen diger varliklar
+                # (bkz. `_ek_sembolleri_getir`) - orchestrator bunlari da
+                # "mentioned_assets" listesine ekler. Coklu soru degilse bos
+                # liste, eski tek-sembol davranisi DEGISMEZ.
+                "additional_symbols": ek_sembol_verileri,
             },
             # Reducer'li alan: yalnizca bu turda bulunan kaynaklar eklenir.
             "sources": kaynaklar,
@@ -1575,6 +1687,62 @@ class MarketResearchAgent(BaseAgent):
     # ------------------------------------------------------------------
     # Canli veri yolu (MCP Server 3)
     # ------------------------------------------------------------------
+
+    async def _ek_sembolleri_getir(
+        self, task: dict[str, Any], query: str
+    ) -> tuple[list[str], list[dict[str, Any]]]:
+        """Sorguda BIRINCIL sembolun (`task["symbol"]`) yaninda gecen DIGER
+        varliklarin canli fiyatini getirir ("NVIDIA ve Apple ne durumda").
+
+        ⚠️ YALNIZCA FIYAT - `_run_live`'in aksine gecmis/mevsimsellik/KAP
+        bildirimi CEKMEZ. Amac bu ikincil varliklar icin kisa bir referans
+        noktasi vermek, birincil varlikla AYNI DERINLIKTE analiz degil: coklu
+        varlikta her biri icin tam analiz cekmek hem gecikmeyi hem tool
+        cagrisi sayisini katlardi.
+
+        Tool cagrisi basarisiz olursa (sembol bulunamadi, gecici hata) o
+        sembol SESSIZCE atlanir - birincil varligin cevabini bozmamali.
+        """
+        katalog = await self._symbol_catalog()
+        if not katalog:
+            return [], []
+
+        ek_semboller = resolve_symbols(query, katalog, disla=task.get("symbol"))
+        if not ek_semboller:
+            return [], []
+
+        ozet_satirlari: list[str] = []
+        veriler: list[dict[str, Any]] = []
+        for sembol in ek_semboller:
+            try:
+                quote = await self.call_tool(
+                    server=MARKET_SERVER_NAME,
+                    tool="market_get_quote",
+                    arguments={"symbol": sembol},
+                )
+            except MCPToolExecutionError:
+                logger.warning(
+                    "ek sembol icin canli fiyat alinamadi", extra={"symbol": sembol}, exc_info=True
+                )
+                continue
+
+            if quote.get("price") is None:
+                continue
+
+            veriler.append(
+                {
+                    "symbol": quote.get("symbol") or sembol,
+                    "price": quote["price"],
+                    "currency": quote.get("currency"),
+                    "daily_change_pct": quote.get("daily_change_pct"),
+                }
+            )
+            degisim = quote.get("daily_change_pct") or 0
+            ozet_satirlari.append(
+                f"{quote.get('symbol') or sembol} guncel fiyat: {quote['price']} "
+                f"{quote.get('currency') or ''} ({degisim:+.2f}%)."
+            )
+        return ozet_satirlari, veriler
 
     async def _run_live(self, task: dict[str, Any]) -> tuple[str | None, dict[str, Any] | None]:
         """Canli fiyat ve (istenirse) son KAP bildirimini getirir.

--- a/backend/app/api/routes/market.py
+++ b/backend/app/api/routes/market.py
@@ -3,6 +3,7 @@
 from typing import Literal
 
 from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
 
 from app.auth.deps import CurrentUser
 from app.forecast import service as forecast_service
@@ -17,6 +18,7 @@ from app.schemas.market import (
     OhlcResponse,
     PhotoResponse,
 )
+from app.services import chat as chat_service
 from app.services import market as service
 from app.services import news as news_service
 
@@ -156,3 +158,39 @@ async def forecast_portfolio(user: CurrentUser) -> Tahmin | None:
     `engine.py::portfoy_tahmini_birlestir`.
     """
     return await forecast_service.portfoy_tahmini(user["id"])
+
+
+@router.get("/quick-analysis")
+async def quick_analysis(
+    user: CurrentUser, symbol: str = Query(description="Varlik kodu (orn. THYAO, GRAM_ALTIN)")
+) -> StreamingResponse:
+    """Varlik kartindaki "Polifin AI Analizi" kutusu icin SSE akisi.
+
+    `symbol` SORGU PARAMETRESIDIR - kardes uc `/forecast` ile ayni gerekce
+    (yol parcasinda "/" iceren sembollerde 404).
+
+    ⚠️ /chat/stream ILE KARISTIRILMASIN: bu uc HICBIR sohbet oturumu
+    ACMAZ/KAYDETMEZ (bkz. `chat_service.stream_quick_analysis`). Varlik
+    kartina tiklamak eskiden kullanicinin GERCEK sohbet gecmisine bir mesaj
+    yaziyordu - kullanici hic yazmadigi bir soruyu sonradan sohbetinde
+    goruyordu. Bu uc ayni orkestratoru kalici kayit olmadan cagirir.
+
+    Olay sozlesmesi `chat.py`'deki `/chat/stream` ile AYNIDIR (`status`,
+    `token`, `agent_error`, `error`, `done`) - yalnizca `meta`/`sources`/
+    `rapor` alanlari bu baglamda anlamsizdir, frontend bunlari yok sayar.
+    """
+    olaylar = chat_service.stream_quick_analysis(user_id=user["id"], symbol=symbol)
+
+    async def event_body():
+        async for event in olaylar:
+            yield chat_service.format_sse(event)
+
+    return StreamingResponse(
+        event_body(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/app/engine/orchestrator.py
+++ b/backend/app/engine/orchestrator.py
@@ -60,7 +60,6 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 
 from app.agents.base import BaseAgent
-from app.agents.portfolio import gunun_hareketlileri
 from app.agents.security_agent import PII_FLAG
 from app.config import settings
 from app.core.llm import _is_transient_error
@@ -1401,10 +1400,6 @@ class Orchestrator:
         #: ilk token'dan once gitme zorunlulugu yok, cunku frontend karti
         #: cevap TAMAMLANDIKTAN sonra gosterir.
         bahsedilen_semboller: list[str] = []
-        #: Portfoy ajani calistiysa gunun en hareketli pozisyonlari - piyasa
-        #: ajaninin sembolu TEK bir varlik veriyor, portfoy sorularinda ise
-        #: cevap birden fazla pozisyondan bahsediyor.
-        hareketli_semboller: list[str] = []
         son_yanit: str | None = None
         #: Kullaniciya GERCEKTEN gonderilmis token'lar. Nihai metin bundan
         #: uzunsa aradaki fark sonda ek token olarak yollanir (bkz. asagisi).
@@ -1455,15 +1450,17 @@ class Orchestrator:
 
                         piyasa_verisi = update.get("market_data")
                         if isinstance(piyasa_verisi, dict) and piyasa_verisi.get("symbol"):
-                            bahsedilen_semboller = [piyasa_verisi["symbol"]]
-
-                        portfoy_verisi = update.get("portfolio_data")
-                        if isinstance(portfoy_verisi, dict):
-                            hareketli_semboller = [
-                                h["symbol"]
-                                for h in gunun_hareketlileri(portfoy_verisi)
-                                if h.get("symbol")
-                            ]
+                            # Birincil sembol ONCE, ardindan ayni sorguda
+                            # gecen DIGER varliklar ("NVIDIA ve Apple ne
+                            # durumda" gibi coklu sorularda) - bkz.
+                            # MarketResearchAgent._ek_sembolleri_getir.
+                            # Tekliler icin `additional_symbols` hep bos
+                            # liste doner, eski davranis DEGISMEZ.
+                            ek = piyasa_verisi.get("additional_symbols") or []
+                            ek_semboller = (
+                                e["symbol"] for e in ek if isinstance(e, dict) and e.get("symbol")
+                            )
+                            bahsedilen_semboller = [piyasa_verisi["symbol"], *ek_semboller]
 
                         # Kismi basarisizlik: tek ajan coktu, sohbet DEVAM
                         # ediyor. Frontend bunu uyari olarak gosterir, akisi
@@ -1537,11 +1534,17 @@ class Orchestrator:
         bitis_olayi: dict = {
             "type": "done",
             "latency_ms": round((time.perf_counter() - baslangic) * 1000, 2),
-            # Sorulan varlik once, ardindan gunun hareketlileri; tekrarlar
-            # elenir ve kart sayisi sinirlanir.
-            "mentioned_assets": list(dict.fromkeys([*bahsedilen_semboller, *hareketli_semboller]))[
-                :KART_SEMBOL_SINIRI
-            ],
+            # ⚠️ YALNIZCA gercekten SORULAN/dogrulanan varlik - "gunun
+            # hareketlileri" (portfoydeki en cok degisen pozisyonlar) BURAYA
+            # BILEREK EKLENMEZ. Onceki halde eklenıyordu ve cevap metni o
+            # varlıklardan HIC bahsetmese bile kart olarak beliriyorlardı -
+            # kullanici bunu "alakasiz varlik kartlari" olarak bildirdi
+            # (canli ornek: GUMUS sorulunca cevapta hic gecmeyen EREGL/BTC
+            # kartlari da geliyordu). `gunun_hareketlileri()` kendisi hala
+            # var ve portfoy ajaninin OZET METNINDE kullaniliyor
+            # (app/agents/portfolio.py) - yalnizca bu karta SIZMASI
+            # engellendi.
+            "mentioned_assets": bahsedilen_semboller[:KART_SEMBOL_SINIRI],
         }
         if uretilen_rapor:
             # `rapor`: yalnizca META veri (dosya adi/boyut) - SSE'ye JSON

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -21,6 +21,8 @@ import base64
 import binascii
 import json
 import logging
+import random
+import uuid
 from collections.abc import AsyncGenerator
 
 from app.config import settings
@@ -194,6 +196,42 @@ async def stream_chat_response(
                 # baglantisi cizer.
                 event.pop("rapor", None)
 
+        yield event
+
+
+async def stream_quick_analysis(user_id: int, symbol: str) -> AsyncGenerator[dict, None]:
+    """Varlik kartindaki "Polifin AI Analizi" kutusu icin TEK SEFERLIK,
+    KALICI OLMAYAN bir orkestrator cagrisi.
+
+    ⚠️ `stream_chat_response`'TAN BILEREK FARKLI: hicbir chat_sessions/
+    chat_messages satiri YAZMAZ. Onceki davranista varlik kartı acilinca
+    `ChatContext` (widget/kart arasinda PAYLASIMLI) uzerinden GERCEK bir
+    sohbet mesaji gonderiliyordu - kullanici hic yazmadigi "X hakkinda
+    kisa bir yatirim analizi yap" sorusunu, dakikalar sonra sohbet
+    penceresini actiginda kendi gecmisinde goruyordu. Bu fonksiyon ayni
+    orkestratoru, kalici bir sohbet OTURUMU ACMADAN dogrudan cagirir.
+
+    `thread_id` NEGATIF ve rastgele secilir: gercek `chat_sessions.id`
+    degerleri (Postgres serial) HER ZAMAN pozitiftir, yani bu deger hicbir
+    gercek oturumla CAKISAMAZ - LangGraph'in bellek ici checkpointer'i
+    (MemorySaver) bu sayede ne gercek bir konusmanin durumunu okur ne de
+    ona yazar.
+    """
+    request_id = str(uuid.uuid4())
+    thread_id = -random.randint(1, 2_000_000_000)
+
+    # MCP tool'lari kimligi buradan okur (bkz. stream_chat_response'daki ayni
+    # notlar) - SSE gövdesi endpoint'ten SONRA calisir, contextvar'lar burada
+    # TEKRAR yazilmali.
+    set_current_user_id(user_id)
+    set_request_context(request_id=request_id, session_id=thread_id)
+
+    async for event in get_orchestrator().stream_request(
+        query=f"{symbol} hakkında kısa bir yatırım analizi yap.",
+        user_id=user_id,
+        thread_id=thread_id,
+        request_id=request_id,
+    ):
         yield event
 
 

--- a/backend/tests/test_market_research_coklu_varlik.py
+++ b/backend/tests/test_market_research_coklu_varlik.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""MarketResearchAgent coklu varlik testleri (resolve_symbols entegrasyonu).
+
+⚠️ `db` ISARETI KULLANILMAZ - `test_market_research_agent.py`'nin aksine
+GERCEK MCP tool'larini (`build_servers()`, PostgreSQL) degil, TAMAMEN
+sahte/bellek ici bir "market" sunucusu kullanir. Amac saf: `_execute`'un
+YENI coklu-sembol dalinin (`_ek_sembolleri_getir`) dogru kablolandigini
+dogrulamak, gercek veri katmanini degil.
+
+CANLI BILDIRILEN HATA: "NVIDIA ve Apple hisseleri ne durumda" sorusuna
+yalnizca BIRINCIL varligin (market_data.symbol - TEK alan) karti
+donuyordu, ikinci varlik sessizce yok sayiliyordu.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agents.market_research import MarketResearchAgent
+from app.mcp.client import MCPClient, MCPServer
+from app.mcp.server import fail, ok
+from app.orchestration.models import AgentState
+
+#: Gercek `market_list_symbols` ciktisiyla ayni sekil - kucuk bir katalog.
+KATALOG = [
+    {"symbol": "ASELS", "ad": "Aselsan", "asset_class": "STOCK"},
+    {"symbol": "SASA", "ad": "Sasa Polyester", "asset_class": "STOCK"},
+    {"symbol": "THYAO", "ad": "Türk Hava Yolları", "asset_class": "STOCK"},
+]
+
+#: Sembol -> sahte kotasyon. Testler kasitli olarak FARKLI fiyat/yon
+#: kullanir ki "ayni veri iki kez donuyor" gibi bir hata gozden kacmasin.
+KOTASYONLAR = {
+    "ASELS": {"price": 390.25, "currency": "TRY", "daily_change_pct": 1.5},
+    "SASA": {"price": 4.12, "currency": "TRY", "daily_change_pct": -2.3},
+    "THYAO": {"price": 302.25, "currency": "TRY", "daily_change_pct": 0.4},
+}
+
+
+def _sahte_market_sunucusu(cagrilan_semboller: list[str] | None = None) -> MCPServer:
+    sunucu = MCPServer("market")
+
+    async def market_list_symbols() -> dict:
+        return ok({"symbols": KATALOG})
+
+    async def market_get_quote(symbol: str) -> dict:
+        if cagrilan_semboller is not None:
+            cagrilan_semboller.append(symbol)
+        kotasyon = KOTASYONLAR.get(symbol)
+        if kotasyon is None:
+            return fail(f"'{symbol}' icin fiyat verisi bulunamadi.")
+        return ok(
+            {
+                "symbol": symbol,
+                "price": kotasyon["price"],
+                "currency": kotasyon["currency"],
+                "daily_change_pct": kotasyon["daily_change_pct"],
+                "ts": "2026-09-03T10:00:00",
+            }
+        )
+
+    sunucu.register_tool("market_list_symbols", market_list_symbols)
+    sunucu.register_tool("market_get_quote", market_get_quote)
+    return sunucu
+
+
+def _ajan(cagrilan_semboller: list[str] | None = None) -> MarketResearchAgent:
+    client = MCPClient({"market": _sahte_market_sunucusu(cagrilan_semboller)})
+    return MarketResearchAgent(mcp_client=client, llm=None, timeout_seconds=5)
+
+
+def _state(sorgu: str, sembol: str) -> AgentState:
+    """`mode`/`symbol`'u ACIKCA verir - regex/NLP siniflandirmasina bagimli
+    olmadan yalnizca `_execute`'un coklu-sembol dalini test eder."""
+    return AgentState(
+        user_query=sorgu,
+        user_id=1,
+        thread_id=1,
+        agent_tasks={"market_research": {"mode": "live", "symbol": sembol}},
+        requested_agents=["market_research"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_coklu_varlik_sorusunda_ikinci_sembol_de_market_datada_gorunur():
+    ajan = _ajan()
+
+    sonuc = await ajan._execute(_state("ASELS ve SASA hisseleri ne durumda", "ASELS"))
+
+    ek = sonuc["market_data"]["additional_symbols"]
+    assert [e["symbol"] for e in ek] == ["SASA"]
+    assert ek[0]["price"] == 4.12
+
+
+@pytest.mark.asyncio
+async def test_ikinci_sembolun_ozeti_sentez_metnine_girer():
+    """Kart gorunup de cevap metni ikinci varliktan HIC bahsetmemesi -
+    kullaniciya kart ile metin arasinda tutarsizlik olarak gorunurdu."""
+    ajan = _ajan()
+
+    sonuc = await ajan._execute(_state("ASELS ve SASA hisseleri ne durumda", "ASELS"))
+
+    assert "SASA" in sonuc["market_data"]["summary"]
+    assert "4.12" in sonuc["market_data"]["summary"] or "4,12" in sonuc["market_data"]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_tek_varlikli_soruda_additional_symbols_bos_kalir():
+    """Eski (tek sembol) davranis DEGISMEMELI - regresyon korumasi."""
+    ajan = _ajan()
+
+    sonuc = await ajan._execute(_state("ASELS hissesi ne durumda", "ASELS"))
+
+    assert sonuc["market_data"]["additional_symbols"] == []
+
+
+@pytest.mark.asyncio
+async def test_uc_varlik_sorulursa_ucu_de_gelir():
+    ajan = _ajan()
+
+    sonuc = await ajan._execute(_state("ASELS SASA ve THYAO nasil gidiyor", "ASELS"))
+
+    ek = sonuc["market_data"]["additional_symbols"]
+    assert {e["symbol"] for e in ek} == {"SASA", "THYAO"}
+
+
+@pytest.mark.asyncio
+async def test_ek_sembolun_fiyati_bulunamazsa_sessizce_atlanir():
+    """MCP tool'u basarisiz olursa (sembol yok, gecici hata) o sembol
+    SESSIZCE atlanir - birincil varligin cevabini BOZMAMALI."""
+    ajan = _ajan()
+
+    sonuc = await ajan._execute(_state("ASELS ve OLMAYANSEMBOL nasil", "ASELS"))
+
+    # "OLMAYANSEMBOL" katalogda yok, resolve_symbols zaten bulamaz - test
+    # asil onemli olani dogruluyor: katalogda olmayan bir kelime yuzunden
+    # `_execute` PATLAMAZ, birincil varlik normal doner.
+    assert sonuc["market_data"]["symbol"] == "ASELS"
+    assert sonuc["market_data"]["additional_symbols"] == []
+
+
+@pytest.mark.asyncio
+async def test_ek_semboller_icin_yalnizca_fiyat_cekilir_tam_analiz_degil():
+    """`_ek_sembolleri_getir` yalnizca `market_get_quote` cagirmali -
+    `market_get_kap_disclosures` gibi ek tool'lar TETIKLENMEMELI (coklu
+    varlikta her biri icin tam analiz cekmek gecikmeyi katlardi)."""
+    cagrilan: list[str] = []
+    ajan = _ajan(cagrilan)
+
+    await ajan._execute(_state("ASELS ve SASA hisseleri ne durumda", "ASELS"))
+
+    # Birincil (ASELS, `_run_live` uzerinden) + ikincil (SASA, `_ek_sembolleri_getir`
+    # uzerinden) - ikisi de SADECE market_get_quote cagirir, sunucumuzda
+    # baska tool kayitli bile degil (kayitli olmayani cagirsaydi patlardi).
+    assert cagrilan == ["ASELS", "SASA"]

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -1136,9 +1136,17 @@ async def test_fallback_reply_orders_sections_by_router_order():
     assert metin.index("Piyasa araştırması") < metin.index("Portföy analizi")
 
 
-async def test_kart_sembolleri_gunun_hareketlilerini_de_icerir():
-    """Kart hep piyasa ajaninin TEK sembolunu gosteriyordu: gunluk ozette bu
-    her seferinde ayni hisse oluyordu. Gunun hareketlileri de eklenir."""
+async def test_kart_sembolleri_gunun_hareketlilerini_ICERMEZ():
+    """REGRESYON KORUMASI - canli hata.
+
+    Onceki halde portfoy ajani calistiginda "gunun hareketlileri" (en cok
+    degisen 3 pozisyon) otomatik olarak karta ekleniyordu - cevap METNI o
+    varliklardan HIC bahsetmese bile. Canlida gozlemlendi: "GUMUS hakkında
+    ... analiz yap" sorusuna cevap yalnizca GUMUS'tan bahsederken, kart
+    listesinde cevapta hic gecmeyen EREGL/BTC de beliriyordu - kullanici
+    bunu "alakasiz varlik kartlari" olarak bildirdi. Kart artik YALNIZCA
+    piyasa ajaninin dogruladigi (gercekten sorulan) sembolu icermeli.
+    """
     ajanlar = _uc_ajan()
     ajanlar[AGENT_PORTFOLIO] = SahteAjan(
         AGENT_PORTFOLIO,
@@ -1158,11 +1166,13 @@ async def test_kart_sembolleri_gunun_hareketlilerini_de_icerir():
     olaylar = await _olaylar(orchestrator, "Portföyümün dağılımı nedir?")
 
     bitis = next(o for o in olaylar if o["type"] == "done")
-    assert bitis["mentioned_assets"] == ["BAKIR", "ASELS", "TCELL"]
+    assert bitis["mentioned_assets"] == []
 
 
-async def test_kart_sembolleri_sinirlanir_ve_tekrar_etmez():
-    """Piyasa sembolu once gelir, ayni sembol iki kez yazilmaz."""
+async def test_kart_piyasa_sembolu_varken_portfoy_hareketlilerini_yutmaz():
+    """Piyasa VE portfoy ajani birlikte calissa bile kart yalnizca piyasa
+    ajaninin dogruladigi sembolu gosterir - portfoydeki digger pozisyonlar
+    (BAKIR haric) cevapta gecmedigi icin karta SIZMAMALI."""
     ajanlar = _uc_ajan()
     ajanlar[AGENT_MARKET_RESEARCH] = SahteAjan(
         AGENT_MARKET_RESEARCH, {"market_data": {"symbol": "BAKIR"}}
@@ -1185,7 +1195,34 @@ async def test_kart_sembolleri_sinirlanir_ve_tekrar_etmez():
     olaylar = await _olaylar(orchestrator, "Portföyümün dağılımı nedir?")
 
     bitis = next(o for o in olaylar if o["type"] == "done")
-    assert bitis["mentioned_assets"] == ["BAKIR", "ASELS", "TCELL"]
+    assert bitis["mentioned_assets"] == ["BAKIR"]
+
+
+async def test_kart_coklu_varlik_sorusunda_ikincil_sembolu_de_icerir():
+    """CANLI BILDIRILEN HATA: 'NVIDIA ve Apple hisseleri ne durumda' gibi
+    coklu sorularda yalnizca BIRINCIL varligin karti geliyordu. Piyasa
+    ajani ikincil varliklari `market_data.additional_symbols` ile
+    bildirdiginde (bkz. MarketResearchAgent._ek_sembolleri_getir), kart
+    listesi birincil sembolun ARDINDAN bunlari da icermeli."""
+    ajanlar = _uc_ajan()
+    ajanlar[AGENT_MARKET_RESEARCH] = SahteAjan(
+        AGENT_MARKET_RESEARCH,
+        {
+            "market_data": {
+                "symbol": "ASELS",
+                "additional_symbols": [
+                    {"symbol": "SASA", "price": 4.12},
+                    {"symbol": "THYAO", "price": 302.25},
+                ],
+            }
+        },
+    )
+    orchestrator = _orchestrator(agents=ajanlar)
+
+    olaylar = await _olaylar(orchestrator, "ASELS ve SASA hisseleri ne durumda")
+
+    bitis = next(o for o in olaylar if o["type"] == "done")
+    assert bitis["mentioned_assets"] == ["ASELS", "SASA", "THYAO"]
 
 
 async def test_kart_sembolleri_portfoysuz_soruda_degismez():

--- a/backend/tests/test_quick_analysis.py
+++ b/backend/tests/test_quick_analysis.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Varlik karti "Polifin AI Analizi" kutusu icin `quick_analysis` testleri.
+
+⚠️ `db` ISARETI KULLANILMAZ - ayni gerekce test_chat_attachments.py'de: bu
+testler `get_orchestrator`'i SAHTE bir nesneyle degistirir, gercek
+veritabanina hic dokunulmaz. Asil dogrulanan sey: bu yolun `chat_sessions`/
+`chat_messages`'a HICBIR SEY YAZMADIGI (bkz. `chat_service.stream_quick_analysis`
+docstring'i - varlik kartina tiklamak eskiden kullanicinin GERCEK sohbet
+gecmisine bir mesaj yaziyordu).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.repositories.in_memory import InMemoryChatRepository
+from app.services import chat as chat_service
+
+
+class _SahteOrchestrator:
+    """`stream_request` cagrisinin argumanlarini yakalar."""
+
+    def __init__(self):
+        self.son_cagri_kwargs: dict | None = None
+
+    async def stream_request(self, **kwargs):
+        self.son_cagri_kwargs = kwargs
+        yield {
+            "type": "meta",
+            "request_id": kwargs.get("request_id", ""),
+            "conversation_id": kwargs["thread_id"],
+        }
+        yield {"type": "status", "stage": "agents", "message": "Piyasa araştırması yapılıyor"}
+        yield {"type": "token", "content": "GUMUS "}
+        yield {"type": "token", "content": "kısa vadede yatay seyrediyor."}
+        yield {"type": "done", "latency_ms": 42.0, "mentioned_assets": []}
+
+
+@pytest.mark.asyncio
+async def test_sorgu_beklenen_formatta_uretilir(monkeypatch):
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+
+    _ = [e async for e in chat_service.stream_quick_analysis(user_id=7, symbol="GUMUS")]
+
+    assert sahte.son_cagri_kwargs["query"] == "GUMUS hakkında kısa bir yatırım analizi yap."
+    assert sahte.son_cagri_kwargs["user_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_thread_id_negatif_gercek_oturumla_cakismaz(monkeypatch):
+    """`chat_sessions.id` Postgres serial'dir, HER ZAMAN pozitiftir - negatif
+    bir `thread_id` bu yuzden hicbir gercek oturumla cakisamaz (bkz.
+    `stream_quick_analysis` docstring'i)."""
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+
+    _ = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="BTC")]
+
+    assert sahte.son_cagri_kwargs["thread_id"] < 0
+
+
+@pytest.mark.asyncio
+async def test_her_cagri_farkli_thread_id_uretir(monkeypatch):
+    """Ayni surecte iki ardisik karti acmak AYNI negatif id'yi tekrar
+    kullanmamali - LangGraph'in bellek ici checkpointer'i (MemorySaver) o
+    zaman iki taleplerin gecmisini birbirine karistirirdi."""
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+
+    _ = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="BTC")]
+    ilk = sahte.son_cagri_kwargs["thread_id"]
+    _ = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="BTC")]
+    ikinci = sahte.son_cagri_kwargs["thread_id"]
+
+    assert ilk != ikinci
+
+
+@pytest.mark.asyncio
+async def test_olaylar_oldugu_gibi_iletilir(monkeypatch):
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+
+    olaylar = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="GUMUS")]
+
+    tipler = [o["type"] for o in olaylar]
+    assert tipler == ["meta", "status", "token", "token", "done"]
+    metin = "".join(o["content"] for o in olaylar if o["type"] == "token")
+    assert metin == "GUMUS kısa vadede yatay seyrediyor."
+
+
+@pytest.mark.asyncio
+async def test_chat_repository_hic_cagrilmaz(monkeypatch):
+    """EN KRITIK TEST: bu yol `chat_sessions`/`chat_messages`'a HICBIR SEY
+    yazmamali. `get_chat_repository`'yi hic hazir olmayan bir seye (None)
+    baglayip fonksiyonun ona DOKUNMADIGINI dogruluyoruz - dokunsaydi
+    `AttributeError` firlardi."""
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+    monkeypatch.setattr(
+        chat_service,
+        "get_chat_repository",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("stream_quick_analysis get_chat_repository'yi COGIRMAMALI")
+        ),
+    )
+
+    olaylar = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="GUMUS")]
+
+    assert olaylar[-1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_gercek_bellek_ici_repo_bos_kalir(monkeypatch):
+    """Yukaridaki testin GORSEL kaniti: gercek (bellek ici) bir repo
+    baglansa bile hicbir oturum/mesaj olusmaz."""
+    repo = InMemoryChatRepository()
+    monkeypatch.setattr(chat_service, "get_chat_repository", lambda: repo)
+    sahte = _SahteOrchestrator()
+    monkeypatch.setattr(chat_service, "get_orchestrator", lambda: sahte)
+
+    await repo.create_session(user_id=1, title="Gercek sohbet")
+    onceki_oturum_sayisi = len(await repo.list_sessions(user_id=1))
+
+    _ = [e async for e in chat_service.stream_quick_analysis(user_id=1, symbol="GUMUS")]
+
+    assert len(await repo.list_sessions(user_id=1)) == onceki_oturum_sayisi

--- a/backend/tests/test_sembol_cozumleme.py
+++ b/backend/tests/test_sembol_cozumleme.py
@@ -32,6 +32,7 @@ from app.agents.market_research import (
     _dokuman_bazinda_tekille,
     _icerikten_baslik,
     resolve_symbol,
+    resolve_symbols,
 )
 
 #: Gercek `assets` tablosundaki adlarla ayni - kisaltilmis katalog.
@@ -52,6 +53,11 @@ KATALOG = [
     {"symbol": "LLY", "ad": "Eli Lilly and Company"},
     {"symbol": "BRENT", "ad": "Ham Petrol (BRENT)"},
     {"symbol": "US10Y", "ad": "US 10 Yil Tahvil Getirisi"},
+    # Katalogdaki ad "Erdemir" - "Ereğli" DEGIL (bkz. db/v5_schema_and_data.sql).
+    # Kullanicilar genelde kod kokunden tureyen "ereğli" der; bu yuzden ad
+    # eslesmesi degil kod+ek eslesmesi (EREGL+i) devreye girmeli.
+    {"symbol": "EREGL", "ad": "Erdemir"},
+    {"symbol": "NVDA", "ad": "Nvidia"},
 ]
 
 
@@ -85,6 +91,87 @@ KATALOG = [
 )
 def test_gunluk_dilde_sorulan_varliklar_cozulur(sorgu, beklenen):
     assert resolve_symbol(sorgu, KATALOG) == beklenen
+
+
+# ---------------------------------------------------------------------------
+# resolve_symbols - COKLU varlik tespiti
+#
+# CANLI BILDIRILEN HATA: "NVIDIA ve Apple hisseleri ne durumda" diye sorulunca
+# yalnizca BIRI (market_data.symbol - TEK alan) kart olarak donuyordu, ikinci
+# varlik sessizce yok sayiliyordu. `resolve_symbols` birincil sembolun
+# YANINDA gecen digerlerini de bulur.
+# ---------------------------------------------------------------------------
+
+
+def test_coklu_varlikta_kod_ek_eslesmesi_de_calisir():
+    """REGRESYON KORUMASI - canli hata (3 Eylul 2026).
+
+    "nvidia ve ereğli hisselerinin fiyatlari kaç" sorusunda EREGL hic
+    bulunamiyordu: katalogdaki adi "Erdemir" (Eregli DEGIL), yani ne tam
+    kod eslesmesi ne tam ad eslesmesi tutuyordu. Ilk surumde `resolve_symbols`
+    kod+ek eslesmesini (tier 2) BILEREK atlamisti - bu test o katmanin
+    coklu tespitte de calistigini dogrular.
+    """
+    sonuc = resolve_symbols("nvidia ve ereğli hisselerinin fiyatlari kaç", KATALOG)
+
+    assert sonuc == ["NVDA", "EREGL"]
+
+
+def test_coklu_varlik_ikisi_de_bulunur():
+    sonuc = resolve_symbols("aselsan ve sasa hisseleri ne durumda", KATALOG)
+
+    assert sonuc == ["ASELS", "SASA"]
+
+
+def test_coklu_varlik_sorgudaki_sirayi_korur():
+    sonuc = resolve_symbols("once sasa sonra aselsan nasil gidiyor", KATALOG)
+
+    assert sonuc == ["SASA", "ASELS"]
+
+
+def test_disla_parametresi_birincil_sembolu_cikarir():
+    """Orchestrator birincil sembolu zaten `market_data.symbol`'de tasir -
+    ayni sembolun `additional_symbols`'ta tekrarlanmamasi gerekir."""
+    sonuc = resolve_symbols("aselsan ve sasa hisseleri ne durumda", KATALOG, disla="ASELS")
+
+    assert sonuc == ["SASA"]
+
+
+def test_ayni_varlik_iki_kez_gecerse_tekrarlanmaz():
+    sonuc = resolve_symbols("aselsan aselsan aselsan nasil", KATALOG)
+
+    assert sonuc == ["ASELS"]
+
+
+def test_limit_asilmaz():
+    sonuc = resolve_symbols("aselsan sasa bimas koc holding hepsi nasil", KATALOG, limit=2)
+
+    assert len(sonuc) == 2
+
+
+def test_disla_ile_tek_varlikli_sorguda_bos_liste_doner():
+    """Gercek kullanim: orchestrator birincil sembolu (`resolve_symbol` ile
+    zaten cozulmus) `disla` olarak gecirir - tek varlikli bir soruda bu,
+    hicbir EK varlik olmadigi anlamina gelir (bkz. `_ek_sembolleri_getir`).
+    """
+    assert resolve_symbols("thyao ne kadar", KATALOG, disla="THYAO") == []
+
+
+def test_kisa_kodlar_coklu_taramada_atlanir():
+    """KO/T gibi kisa kodlar gunluk kelimelerle cakisma riski yuzunden
+    coklu tespitte BILEREK dislanir (bkz. resolve_symbols docstring'i) -
+    yalnizca ASELS (uzun/net kod) yakalanmali, KO YAKALANMAMALI."""
+    sonuc = resolve_symbols("aselsan ve ko hisseleri nasil", KATALOG)
+
+    assert sonuc == ["ASELS"]
+
+
+def test_alakasiz_ikinci_kelime_yanlis_pozitif_uretmez():
+    """Genel bir ifade ("ne kadar dustu") ikinci bir varlik SANILMAMALI -
+    yalnizca sorulan ASELS donmeli, baska bir sey EKLENMEMELI."""
+    sonuc = resolve_symbols("aselsan ne kadar dustu bugun", KATALOG)
+
+    assert sonuc == ["ASELS"]
 
 
 @pytest.mark.parametrize(

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -10,6 +10,7 @@ import { useChat } from "../../contexts/ChatContext";
 import { useAuth } from "../../hooks/useAuth";
 import { useDailyBrief } from "../../hooks/useDailyBrief";
 import { useInvestmentPackageFlow } from "../../hooks/useInvestmentPackageFlow";
+import { useTradeProposalFlow } from "../../hooks/useTradeProposalFlow";
 import type { ChatQuickReply } from "../../models/chat";
 import type { PendingAttachment } from "./AttachmentMenu";
 import { ConversationHistory } from "./ConversationHistory";
@@ -132,6 +133,14 @@ export function ChatWidget({
   const chat = useChat();
   const [historyOpen, setHistoryOpen] = useState(false);
   const investmentFlow = useInvestmentPackageFlow({
+    language,
+    appendLocalMessage: chat.appendLocalMessage,
+    updateMessage: chat.updateMessage,
+  });
+  //: Sohbetten AL/SAT emri onerme akisi (TC-020/US14). Yatirim paketi
+  //: akisindan SONRA denenir: paket akisi bir soruyu bekliyorsa yazilan
+  //: metin onun CEVABIDIR, emir niyeti olarak yorumlanmamali.
+  const tradeFlow = useTradeProposalFlow({
     language,
     appendLocalMessage: chat.appendLocalMessage,
     updateMessage: chat.updateMessage,
@@ -364,6 +373,13 @@ export function ChatWidget({
       return;
     }
 
+    // Emir niyeti ("5 lot THYAO al") yerel olarak karta cevrilir; mesaj
+    // sohbet backend'ine GITMEZ. Emir yine de ancak kart onaylandiginda
+    // olusur (bkz. TradeProposalCard).
+    if (!attachment && tradeFlow.handleUserMessage(trimmed)) {
+      return;
+    }
+
     chat.sendMessage(trimmed, attachment);
   }
 
@@ -485,6 +501,7 @@ export function ChatWidget({
             quickRepliesDisabled={chat.isStreaming}
             onQuickReply={selectQuickReply}
             onPackagePurchased={investmentFlow.notifyPurchased}
+            onTradeProposalUpdate={tradeFlow.updateProposal}
             emptyState={
               canSend ? (
                 copy.welcome

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
-import type { ChatMessage, ChatQuickReply } from "../../models/chat";
+import type { ChatMessage, ChatQuickReply, TradeProposal } from "../../models/chat";
 import { downloadChatReport } from "../../services/chatService";
 import { AgentErrorNotice } from "./AgentErrorNotice";
 import { InvestmentPackageCard } from "./InvestmentPackageCard";
 import { MentionedAssetCard } from "./MentionedAssetCard";
 import { QuickReplies } from "./QuickReplies";
+import { TradeProposalCard } from "./TradeProposalCard";
 import { SourceList } from "./SourceList";
 
 function ReportDownloadButton({ messageId, fileName }: { messageId: number; fileName: string }) {
@@ -62,6 +63,7 @@ export function MessageList({
   quickRepliesDisabled,
   onQuickReply,
   onPackagePurchased,
+  onTradeProposalUpdate,
 }: {
   messages: ChatMessage[];
   emptyState?: ReactNode;
@@ -71,6 +73,8 @@ export function MessageList({
   quickRepliesDisabled?: boolean;
   onQuickReply?: (reply: ChatQuickReply) => void;
   onPackagePurchased?: (orderCount: number) => void;
+  /** Kartta adet degistiginde guncel oneriyi mesaja geri yazar. */
+  onTradeProposalUpdate?: (messageId: string, proposal: TradeProposal) => void;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   //: Kullanici yukari kaydirdiysa yeni token'lar onu asagi SURUKLEMEZ;
@@ -80,7 +84,7 @@ export function MessageList({
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
   const lastMessage = messages[messages.length - 1];
   const lastMessageKey = lastMessage
-    ? `${lastMessage.id}:${lastMessage.content.length}:${lastMessage.quickReplies?.length ?? 0}:${lastMessage.investmentPackage ? 1 : 0}`
+    ? `${lastMessage.id}:${lastMessage.content.length}:${lastMessage.quickReplies?.length ?? 0}:${lastMessage.investmentPackage ? 1 : 0}:${lastMessage.tradeProposal ? 1 : 0}`
     : "";
 
   function isNearBottom(container: HTMLDivElement): boolean {
@@ -164,6 +168,12 @@ export function MessageList({
             <InvestmentPackageCard
               investmentPackage={message.investmentPackage}
               onPurchased={onPackagePurchased}
+            />
+          )}
+          {message.role === "assistant" && message.tradeProposal && (
+            <TradeProposalCard
+              proposal={message.tradeProposal}
+              onUpdate={(next) => onTradeProposalUpdate?.(message.id, next)}
             />
           )}
           {message.role === "assistant" && message.quickReplies && onQuickReply && (

--- a/frontend/src/components/chat/TradeProposalCard.tsx
+++ b/frontend/src/components/chat/TradeProposalCard.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useLanguage } from "../../contexts/LanguageContext";
+import type { TradeProposal } from "../../models/chat";
+import { createPaperOrder, previewPaperOrder } from "../../services/tradingService";
+import { invalidQuantityMessage, isValidQuantity, quantityStep } from "../../utils/assetQuantity";
+
+const COPY = {
+  tr: {
+    buy: "AL",
+    sell: "SAT",
+    quantity: "Adet",
+    unitPrice: "Birim fiyat",
+    commission: "Komisyon",
+    total: "Toplam",
+    afterTrade: "İşlem sonrası nakit",
+    holding: "Portföydeki adet",
+    confirm: "Onayla",
+    edit: "Düzenle",
+    cancel: "İptal",
+    apply: "Güncelle",
+    back: "Vazgeç",
+    submitting: "Emir gönderiliyor…",
+    previewing: "Yeniden hesaplanıyor…",
+    done: (side: string) => `${side} emri oluşturuldu`,
+    cancelled: "Emir iptal edildi",
+    failed: "Emir oluşturulamadı.",
+    previewFailed: "Yeni adet için hesap yapılamadı.",
+    quantityLabel: "Yeni adet",
+    disclaimer: "Bu bir yatırım tavsiyesi değildir; emir sanal portföyünde gerçekleşir.",
+  },
+  en: {
+    buy: "BUY",
+    sell: "SELL",
+    quantity: "Quantity",
+    unitPrice: "Unit price",
+    commission: "Commission",
+    total: "Total",
+    afterTrade: "Cash after trade",
+    holding: "Units held",
+    confirm: "Confirm",
+    edit: "Edit",
+    cancel: "Cancel",
+    apply: "Update",
+    back: "Discard",
+    submitting: "Placing order…",
+    previewing: "Recalculating…",
+    done: (side: string) => `${side} order created`,
+    cancelled: "Order cancelled",
+    failed: "The order could not be created.",
+    previewFailed: "Could not recalculate for the new quantity.",
+    quantityLabel: "New quantity",
+    disclaimer: "This is not investment advice; the order runs in your virtual portfolio.",
+  },
+} as const;
+
+function formatTry(value: number, locale: "tr-TR" | "en-US"): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "TRY",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatQuantity(value: number, locale: "tr-TR" | "en-US"): string {
+  return new Intl.NumberFormat(locale, { maximumFractionDigits: 8 }).format(value);
+}
+
+/**
+ * Sohbet balonu icinde gosterilen emir onay karti (TC-020 / US14).
+ *
+ * ⚠️ RAKAMLARI KENDI HESAPLAMAZ. Fiyat, komisyon, toplam ve kullanilabilir
+ * bakiye backend onizlemesinden gelir; "Duzenle" ile adet degistirildiginde
+ * de YENIDEN ONIZLEME alinir. Boylece kullanicinin onayladigi tutar ile
+ * emrin gercek maliyeti ayrisamaz.
+ *
+ * Onay TEK TIKTIR ama emir yine de iki asamalidir: kart zaten onizlenmis
+ * (dogrulanmis) bir emri gosterir, "Onayla" yalnizca onu isler.
+ */
+export function TradeProposalCard({
+  proposal,
+  onUpdate,
+}: {
+  proposal: TradeProposal;
+  /** Adet degistiginde guncel oneriyi mesaja geri yazar (kalicilik icin). */
+  onUpdate?: (next: TradeProposal) => void;
+}) {
+  const { language } = useLanguage();
+  const copy = COPY[language] ?? COPY.tr;
+  const locale = language === "tr" ? "tr-TR" : "en-US";
+
+  const [state, setState] = useState<"idle" | "editing" | "previewing" | "submitting" | "done" | "cancelled">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [draftQuantity, setDraftQuantity] = useState(String(proposal.preview.quantity));
+
+  const { preview, assetClass } = proposal;
+  const sideLabel = preview.side === "BUY" ? copy.buy : copy.sell;
+  const isBuy = preview.side === "BUY";
+  const afterTrade = isBuy
+    ? preview.available_balance - preview.estimated_total
+    : preview.available_balance + preview.estimated_total;
+
+  async function applyQuantity() {
+    const parsed = Number(draftQuantity.replace(",", "."));
+    if (!isValidQuantity(parsed, assetClass)) {
+      setError(invalidQuantityMessage(assetClass, language));
+      return;
+    }
+
+    setState("previewing");
+    setError(null);
+    try {
+      const next = await previewPaperOrder(
+        preview.symbol,
+        preview.side,
+        parsed,
+        "MARKET",
+        null,
+        "GTC",
+        null,
+      );
+      onUpdate?.({ preview: next, assetClass });
+      setState("idle");
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : copy.previewFailed);
+      setState("editing");
+    }
+  }
+
+  async function confirm() {
+    setState("submitting");
+    setError(null);
+    try {
+      await createPaperOrder(
+        preview.symbol,
+        preview.side,
+        preview.quantity,
+        crypto.randomUUID(),
+        "MARKET",
+        null,
+        "GTC",
+        null,
+      );
+      setState("done");
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : copy.failed);
+      setState("idle");
+    }
+  }
+
+  const rows: Array<[string, string]> = [
+    [copy.quantity, formatQuantity(preview.quantity, locale)],
+    [copy.unitPrice, formatTry(preview.quoted_price, locale)],
+    [copy.commission, formatTry(preview.estimated_commission, locale)],
+    [copy.total, formatTry(preview.estimated_total, locale)],
+    [copy.afterTrade, formatTry(afterTrade, locale)],
+  ];
+  if (!isBuy) {
+    rows.splice(1, 0, [copy.holding, formatQuantity(preview.holding_quantity, locale)]);
+  }
+
+  return (
+    <div className="mt-2 rounded-xl border app-border app-surface p-3 text-xs">
+      <div className="mb-2 flex items-center gap-2">
+        <span
+          className={`rounded-md px-2 py-0.5 text-[11px] font-bold ${
+            isBuy ? "bg-emerald-500/15 text-emerald-600" : "bg-rose-500/15 text-rose-600"
+          }`}
+        >
+          {sideLabel}
+        </span>
+        <span className="font-semibold app-heading">{preview.asset_name}</span>
+        <span className="app-muted">{preview.symbol}</span>
+      </div>
+
+      <dl className="space-y-1">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-center justify-between gap-3">
+            <dt className="app-muted">{label}</dt>
+            <dd className="font-medium app-heading">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {state === "editing" && (
+        <div className="mt-2 flex items-center gap-2">
+          <label className="sr-only" htmlFor={`adet-${preview.symbol}`}>
+            {copy.quantityLabel}
+          </label>
+          <input
+            id={`adet-${preview.symbol}`}
+            type="number"
+            min="0"
+            step={quantityStep(assetClass) === "any" ? "any" : quantityStep(assetClass)}
+            value={draftQuantity}
+            onChange={(event) => setDraftQuantity(event.target.value)}
+            className="w-24 rounded-lg border app-border app-card px-2 py-1 text-xs app-heading"
+          />
+          <button
+            type="button"
+            onClick={() => void applyQuantity()}
+            className="rounded-lg app-primary px-3 py-1 text-xs font-semibold"
+          >
+            {copy.apply}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setDraftQuantity(String(preview.quantity));
+              setError(null);
+              setState("idle");
+            }}
+            className="rounded-lg border app-border px-3 py-1 text-xs font-semibold app-muted"
+          >
+            {copy.back}
+          </button>
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-[11px] app-danger">{error}</p>}
+
+      {state === "done" ? (
+        <p className="mt-2 text-[11px] font-semibold app-success">{copy.done(sideLabel)}</p>
+      ) : state === "cancelled" ? (
+        <p className="mt-2 text-[11px] app-muted">{copy.cancelled}</p>
+      ) : (
+        <>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={state === "submitting" || state === "previewing" || state === "editing"}
+              onClick={() => void confirm()}
+              className="rounded-lg app-primary px-3 py-1.5 text-xs font-semibold disabled:opacity-60"
+            >
+              {state === "submitting" ? copy.submitting : copy.confirm}
+            </button>
+            <button
+              type="button"
+              disabled={state === "submitting" || state === "previewing"}
+              onClick={() => setState(state === "editing" ? "idle" : "editing")}
+              className="rounded-lg border app-border px-3 py-1.5 text-xs font-semibold app-muted disabled:opacity-60"
+            >
+              {state === "previewing" ? copy.previewing : copy.edit}
+            </button>
+            <button
+              type="button"
+              disabled={state === "submitting" || state === "previewing"}
+              onClick={() => setState("cancelled")}
+              className="rounded-lg border app-border px-3 py-1.5 text-xs font-semibold app-muted disabled:opacity-60"
+            >
+              {copy.cancel}
+            </button>
+          </div>
+          <p className="mt-2 text-[10px] leading-relaxed app-muted">{copy.disclaimer}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/market/AssetSummaryModal.tsx
+++ b/frontend/src/components/market/AssetSummaryModal.tsx
@@ -1,12 +1,75 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { useChat } from "../../contexts/ChatContext";
 import type { Asset, HistoryResponse, OhlcResponse } from "../../models/market";
-import { getMarketAssets, getMarketHistory, getMarketOhlc } from "../../services/marketService";
+import { getMarketAssets, getMarketHistory, getMarketOhlc, streamQuickAnalysis } from "../../services/marketService";
 import { CandlestickChart } from "./CandlestickChart";
+
+/**
+ * Varlik karti icin TEK SEFERLIK "Polifin AI Analizi" metni.
+ *
+ * ⚠️ KASITLI OLARAK `ChatContext` KULLANMAZ (bkz. `marketService.streamQuickAnalysis`
+ * docstring'i). Onceki halde bu analiz `useChat().sendMessage(...)` ile
+ * PAYLASIMLI sohbet baglamina gonderiliyordu - kullanici widget'i actiginda
+ * hic yazmadigi "X hakkinda kisa bir yatirim analizi yap" sorusunu kendi
+ * sohbet gecmisinde goruyordu. Bu hook TAMAMEN yerel state tutar; ne
+ * widget'a ne kalici sohbet gecmisine hicbir sey sizmaz.
+ */
+function useQuickAnalysis(symbol: string, isAuthenticated: boolean) {
+  const [content, setContent] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    // ⚠️ BURADA "sadece bir kez sor" REF'I KULLANILMAZ. React StrictMode
+    // (frontend/next.config.js: reactStrictMode=true) gelistirmede HER
+    // effect'i mount->cleanup->mount olarak IKI KEZ calistirir - bir ref
+    // koruması ikinci calistirmayi engellerdi ama asagidaki cleanup zaten
+    // ILK istegi abort() ile iptal etmisti; sonuc TAMAMEN cevapsiz kalan
+    // bir istek olurdu (canli olculdu - kutu sonsuza dek "Analiz
+    // hazirlaniyor..." de takili kaliyordu). AbortController + cleanup tek
+    // basina yeterli: her effect calistirmasi ONCEKI istegi iptal edip
+    // KENDI TEMIZ istegini baslatir, StrictMode'un ikinci calistirmasi da
+    // dahil - sonda hep TEK ve TAMAMLANAN bir istek kalir.
+    setContent("");
+    setStatus(null);
+    setError(null);
+    setIsStreaming(true);
+
+    const controller = new AbortController();
+    streamQuickAnalysis(
+      symbol,
+      (event) => {
+        if (event.type === "status") setStatus(event.message);
+        if (event.type === "token") setContent((current) => current + event.content);
+        if (event.type === "error") setError(event.message);
+        if (event.type === "done") setIsStreaming(false);
+      },
+      controller.signal,
+    )
+      .catch((exc) => {
+        // Modal kapanip AbortController.abort() cagrildiginda `fetch` bu
+        // istisnayla reddeder - bu bir HATA DEGIL, kullanicinin kendi
+        // eylemi. Sessizce yutulur.
+        if (exc instanceof DOMException && exc.name === "AbortError") {
+          return;
+        }
+        setError("Analiz şu anda alınamadı.");
+      })
+      .finally(() => setIsStreaming(false));
+
+    return () => controller.abort();
+  }, [symbol, isAuthenticated]);
+
+  return { content, status, error, isStreaming };
+}
 
 const RANGE_TABS: { label: string; days: number }[] = [
   { label: "1G", days: 1 },
@@ -116,10 +179,7 @@ export function AssetSummaryModal({
   const [chartMode, setChartMode] = useState<"line" | "candle">("line");
   const [ohlc, setOhlc] = useState<OhlcResponse | null>(null);
   const [ohlcLoading, setOhlcLoading] = useState(false);
-  const chat = useChat();
-  const askedRef = useRef<string | null>(null);
-  //: Paylasilan sohbette YALNIZCA bu modalin sordugu sorunun cevabi izlenir.
-  const [analysisMessageId, setAnalysisMessageId] = useState<string | null>(null);
+  const analysis = useQuickAnalysis(symbol, isAuthenticated);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -189,19 +249,6 @@ export function AssetSummaryModal({
     };
   }, [symbol, rangeDays, chartMode, isAuthenticated]);
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      return;
-    }
-
-    if (askedRef.current === symbol) {
-      return;
-    }
-    askedRef.current = symbol;
-    setAnalysisMessageId(chat.sendMessage(`${symbol} hakkında kısa bir yatırım analizi yap.`));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [symbol, isAuthenticated]);
-
   const historyTrendPositive =
     history && history.points.length >= 2
       ? history.points[history.points.length - 1].price >= history.points[0].price
@@ -214,7 +261,6 @@ export function AssetSummaryModal({
   //: (marka yesili / kirmizi, ikisi de tema-duyarli); yon belirsizse notr mavi.
   const aiBoxAccent =
     changeIsPositive == null ? "var(--color-primary)" : changeIsPositive ? "var(--color-brand-teal)" : "var(--color-danger)";
-  const lastAssistantMessage = chat.messages.find((m) => m.id === analysisMessageId);
 
   const sparklinePoints = (history?.points ?? []).slice(-20);
 
@@ -363,10 +409,10 @@ export function AssetSummaryModal({
           >
             <div className="mb-1.5 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide" style={{ color: aiBoxAccent }}>
               <span>Polifin AI Analizi</span>
-              {chat.isStreaming && <span className="app-muted normal-case">{chat.status ?? "…"}</span>}
+              {analysis.isStreaming && <span className="app-muted normal-case">{analysis.status ?? "…"}</span>}
             </div>
             <p className="whitespace-pre-wrap leading-relaxed app-heading">
-              {chat.error ? chat.error : lastAssistantMessage?.content || "Analiz hazırlanıyor…"}
+              {analysis.error ? analysis.error : analysis.content || "Analiz hazırlanıyor…"}
             </p>
           </div>
 

--- a/frontend/src/hooks/useTradeProposalFlow.ts
+++ b/frontend/src/hooks/useTradeProposalFlow.ts
@@ -1,0 +1,232 @@
+"use client";
+
+import { useCallback } from "react";
+import type { AppLanguage } from "../contexts/LanguageContext";
+import type { ChatMessage, TradeProposal } from "../models/chat";
+import type { Asset } from "../models/market";
+import type { OrderPreview } from "../models/trading";
+import { getMarketAssets } from "../services/marketService";
+import { getPortfolioHoldings } from "../services/portfolioService";
+import { previewPaperOrder } from "../services/tradingService";
+import { CEYREK_ADIM, isQuarterStep, isValidQuantity, quantityStep } from "../utils/assetQuantity";
+import type { TradeSide } from "../utils/tradeIntent";
+import { parseTradeIntent, resolveAssetFromText } from "../utils/tradeIntent";
+
+const COPY = {
+  tr: {
+    thinking: "Emri hazırlıyorum…",
+    assetNotFound: (side: string) =>
+      `Hangi varlığı ${side} istediğini anlayamadım. Örnek: "5 lot THYAO ${side}".`,
+    noCash: "Bu işlem için kullanılabilir nakit bakiyen yeterli değil.",
+    noHolding: (symbol: string) => `Portföyünde satılacak ${symbol} pozisyonu bulunmuyor.`,
+    tooMuch: (symbol: string, held: string) =>
+      `Portföyünde yalnızca ${held} adet ${symbol} var; daha fazlasını satamazsın.`,
+    invalidQuantity: "Bu varlık için geçersiz bir adet istedin.",
+    failed: "Emir önerisi hazırlanamadı, lütfen tekrar dene.",
+    buy: "al",
+    sell: "sat",
+    proposal: (side: string, quantity: string, symbol: string) =>
+      `${quantity} adet ${symbol} ${side} emrini hazırladım. Onaylarsan işleme alırım.`,
+  },
+  en: {
+    thinking: "Preparing the order…",
+    assetNotFound: (side: string) =>
+      `I could not tell which asset you want to ${side}. Example: "${side} 5 THYAO".`,
+    noCash: "Your available cash balance is not enough for this trade.",
+    noHolding: (symbol: string) => `You have no ${symbol} position to sell.`,
+    tooMuch: (symbol: string, held: string) =>
+      `You only hold ${held} units of ${symbol}; you cannot sell more.`,
+    invalidQuantity: "That quantity is not valid for this asset.",
+    failed: "The order proposal could not be prepared, please try again.",
+    buy: "buy",
+    sell: "sell",
+    proposal: (side: string, quantity: string, symbol: string) =>
+      `I prepared a ${side} order for ${quantity} ${symbol}. Confirm and I will place it.`,
+  },
+} as const;
+
+/** Varlik sinifina gore adet asagi yuvarlanir (fazlasi bakiyeyi asardi). */
+function floorToStep(quantity: number, assetClass: string): number {
+  if (isQuarterStep(assetClass)) {
+    return Math.floor(quantity / CEYREK_ADIM) * CEYREK_ADIM;
+  }
+  if (quantityStep(assetClass) === "any") {
+    // Serbest ondalikli sinif (kripto): 6 basamak yeterli hassasiyet.
+    return Math.floor(quantity * 1e6) / 1e6;
+  }
+  return Math.floor(quantity);
+}
+
+/**
+ * Sohbetten AL/SAT emri onerme akisi (TC-020 / US14).
+ *
+ * ⚠️ HICBIR EMIR KENDILIGINDEN GONDERILMEZ. Bu akis yalnizca bir ONERI
+ * KARTI uretir; emir ancak kullanici kartta "Onayla"ya bastiginda
+ * (`TradeProposalCard`) olusur. Kart da rakamlari kendi hesaplamaz,
+ * backend onizlemesini gosterir.
+ *
+ * Adet nasil belirlenir:
+ *   1. Kullanici acikca yazdiysa ("5 lot")            -> o adet
+ *   2. TL tutari yazdiysa ("10 bin TL'lik")           -> tutar / birim maliyet
+ *   3. Hicbiri yoksa, ALIM  -> kullanilabilir nakdin tamami
+ *                      SATIM -> portfoydeki tum pozisyon
+ *
+ * Birim maliyet SUNUCUDAN gelir (1 adetlik onizleme): boylece doviz kuru,
+ * komisyon ve fiyat tamponu istemcide TEKRAR HESAPLANMAZ - varliklarin
+ * `current_price` alani kendi para biriminde (USD gibi), nakit ise TL'dir.
+ */
+export function useTradeProposalFlow({
+  language,
+  appendLocalMessage,
+  updateMessage,
+}: {
+  language: AppLanguage;
+  appendLocalMessage: (message: Omit<ChatMessage, "id" | "local">) => string;
+  updateMessage: (id: string, patch: Partial<ChatMessage>) => void;
+}) {
+  const copy = COPY[language] ?? COPY.tr;
+  const locale = language === "tr" ? "tr-TR" : "en-US";
+
+  /** Adet hesabi; hata durumunda kullaniciya gosterilecek METNI doner. */
+  const adetBelirle = useCallback(
+    async (
+      intent: { side: TradeSide; quantity: number | null; amountTry: number | null },
+      asset: Asset,
+    ): Promise<number | string> => {
+      if (intent.side === "SELL") {
+        const holdings = await getPortfolioHoldings();
+        const holding = holdings.items.find(
+          (item) => item.symbol.toUpperCase() === asset.symbol.toUpperCase(),
+        );
+        if (!holding || holding.quantity <= 0) return copy.noHolding(asset.symbol);
+
+        const istenen = intent.quantity ?? holding.quantity;
+        if (istenen > holding.quantity) {
+          return copy.tooMuch(
+            asset.symbol,
+            new Intl.NumberFormat(locale, { maximumFractionDigits: 8 }).format(holding.quantity),
+          );
+        }
+        return isValidQuantity(istenen, asset.asset_class) ? istenen : copy.invalidQuantity;
+      }
+
+      if (intent.quantity !== null) {
+        return isValidQuantity(intent.quantity, asset.asset_class)
+          ? intent.quantity
+          : copy.invalidQuantity;
+      }
+
+      // Adet verilmedi: kucuk bir SONDAJ onizlemesiyle birim maliyeti
+      // sunucudan ogren, sonra butceye (ya da tum nakde) bol.
+      //
+      // ⚠️ SONDAJ ADEDI VARLIK SINIFINA GORE DEGISIR. Bolunebilen
+      // varliklarda (kripto) 1 adetle sormak YANLIS "yetersiz bakiye"
+      // uretirdi: 15.000 TL ile 1 BTC alinamaz ama 0,004 BTC alinabilir.
+      // Tam adet alinan siniflarda ise 1 dogru sondajdir - 1 adedi
+      // alamiyorsa gercekten alamaz.
+      const sondajAdedi = quantityStep(asset.asset_class) === "any" ? 0.001 : 1;
+      let birim: OrderPreview;
+      try {
+        birim = await previewPaperOrder(
+          asset.symbol,
+          "BUY",
+          sondajAdedi,
+          "MARKET",
+          null,
+          "GTC",
+          null,
+        );
+      } catch {
+        // Sondaj adedi bile alinamiyorsa backend "yetersiz bakiye" der.
+        return copy.noCash;
+      }
+
+      const butce = intent.amountTry ?? birim.available_balance;
+      // `estimated_reserve` fiyat tamponu + komisyonu ICERIR; emrin
+      // gercekten gecmesi icin ayrilmasi gereken tutar budur. Sondaj
+      // adedine bolunerek BIR adetin maliyetine cevrilir.
+      const birimMaliyet = (birim.estimated_reserve || birim.estimated_total) / sondajAdedi;
+      if (birimMaliyet <= 0) return copy.failed;
+
+      const adet = floorToStep(butce / birimMaliyet, asset.asset_class);
+      if (adet <= 0) return copy.noCash;
+      return adet;
+    },
+    [copy, locale],
+  );
+
+  const hazirla = useCallback(
+    async (text: string, messageId: string) => {
+      const intent = parseTradeIntent(text);
+      if (!intent) return;
+      const sideWord = intent.side === "BUY" ? copy.buy : copy.sell;
+
+      try {
+        const assets = await getMarketAssets();
+        const asset = resolveAssetFromText(text, assets.items);
+        if (!asset) {
+          updateMessage(messageId, { content: copy.assetNotFound(sideWord) });
+          return;
+        }
+
+        const quantity = await adetBelirle(intent, asset);
+        if (typeof quantity === "string") {
+          updateMessage(messageId, { content: quantity });
+          return;
+        }
+
+        const preview = await previewPaperOrder(
+          asset.symbol,
+          intent.side,
+          quantity,
+          "MARKET",
+          null,
+          "GTC",
+          null,
+        );
+        const proposal: TradeProposal = { preview, assetClass: asset.asset_class };
+        updateMessage(messageId, {
+          content: copy.proposal(
+            sideWord,
+            new Intl.NumberFormat(locale, { maximumFractionDigits: 8 }).format(preview.quantity),
+            asset.symbol,
+          ),
+          tradeProposal: proposal,
+        });
+      } catch (exc) {
+        // Backend is kurali hatalari (yetersiz bakiye vb.) net Turkce mesaj
+        // tasir - oldugu gibi gosterilir; digerleri genel mesaja duser.
+        updateMessage(messageId, {
+          content: exc instanceof Error && exc.message ? exc.message : copy.failed,
+        });
+      }
+    },
+    [adetBelirle, copy, locale, updateMessage],
+  );
+
+  /**
+   * Mesaji yerel olarak isler. `true` donerse mesaj sohbet backend'ine
+   * GONDERILMEZ (bkz. ChatWidget.sendMessage).
+   */
+  const handleUserMessage = useCallback(
+    (text: string): boolean => {
+      if (!parseTradeIntent(text)) return false;
+
+      appendLocalMessage({ role: "user", content: text });
+      const messageId = appendLocalMessage({ role: "assistant", content: copy.thinking });
+      void hazirla(text, messageId);
+      return true;
+    },
+    [appendLocalMessage, copy, hazirla],
+  );
+
+  /** Kartta adet degistiginde guncel oneriyi mesaja geri yazar. */
+  const updateProposal = useCallback(
+    (messageId: string, proposal: TradeProposal) => {
+      updateMessage(messageId, { tradeProposal: proposal });
+    },
+    [updateMessage],
+  );
+
+  return { handleUserMessage, updateProposal };
+}

--- a/frontend/src/models/chat.ts
+++ b/frontend/src/models/chat.ts
@@ -1,3 +1,5 @@
+import type { OrderPreview } from "./trading";
+
 export type Source = {
   doc_id: string;
   baslik: string;
@@ -78,6 +80,29 @@ export type ChatMessage = {
   quickReplies?: ChatQuickReply[];
   /** Ready-made package rendered as a card with a one-tap purchase button. */
   investmentPackage?: InvestmentPackage;
+  /**
+   * Tek varlikli AL/SAT emir onerisi - karttan tek tikla onaylanir
+   * (TC-020/US14). Yerel uretilir, backend'e HIC gitmez; onay aninda
+   * `/api/trading/orders` cagrilir (bkz. `useTradeProposalFlow`).
+   */
+  tradeProposal?: TradeProposal;
+};
+
+/**
+ * Sohbet icinde gosterilen emir onerisi.
+ *
+ * Rakamlarin TAMAMI backend onizlemesinden (`/api/trading/orders/preview`)
+ * gelir - istemci fiyat/komisyon HESAPLAMAZ. Boylece kartta gorunen tutar
+ * ile emrin gercek maliyeti ayrisamaz.
+ */
+export type TradeProposal = {
+  preview: OrderPreview;
+  /**
+   * Varlik sinifi (STOCK/FOREX/CRYPTO...). `OrderPreview` bu alani
+   * tasimaz ama "Duzenle" akisindaki adet dogrulamasi
+   * (`utils/assetQuantity.ts`) buna ihtiyac duyar.
+   */
+  assetClass: string;
 };
 
 export type ChatQuickReply = {

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -1,5 +1,6 @@
 import type { ChatEvent, ChatRequest } from "../models/chat";
 import { getAccessToken, getApiUrl } from "./apiClient";
+import { streamSse } from "./sseStream";
 
 /**
  * Belge analiz raporunu indirir ve tarayicida "farkli kaydet" akisini
@@ -53,43 +54,5 @@ export async function streamChat(
   onEvent: (event: ChatEvent) => void,
   signal?: AbortSignal,
 ): Promise<void> {
-  const token = getAccessToken();
-  const response = await fetch(getApiUrl("/api/chat/stream"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify(payload),
-    signal,
-  });
-
-  if (!response.ok || !response.body) {
-    throw new Error("Sohbet akisi baslatilamadi.");
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-
-    buffer += decoder.decode(value, { stream: true });
-    const chunks = buffer.split("\n\n");
-    buffer = chunks.pop() ?? "";
-
-    for (const chunk of chunks) {
-      const dataLine = chunk
-        .split("\n")
-        .find((line) => line.startsWith("data: "));
-      if (!dataLine) {
-        continue;
-      }
-      onEvent(JSON.parse(dataLine.slice(6)) as ChatEvent);
-    }
-  }
+  return streamSse<ChatEvent>("/api/chat/stream", onEvent, { method: "POST", body: payload, signal });
 }

--- a/frontend/src/services/marketService.ts
+++ b/frontend/src/services/marketService.ts
@@ -13,7 +13,9 @@ import type {
   PublicLandingPreviewResponse,
   PublicMarketTickerResponse,
 } from "../models/market";
+import type { ChatEvent } from "../models/chat";
 import { apiRequest } from "./apiClient";
+import { streamSse } from "./sseStream";
 
 export function getMarketAssets(category?: string): Promise<AssetsResponse> {
   const query = category ? `?category=${encodeURIComponent(category)}` : "";
@@ -108,4 +110,25 @@ export function getForecast(symbol: string): Promise<Forecast | null> {
 /** Portfoyun TUM varliklari + nakdi uzerinden TL bazli birlesik tahmin. */
 export function getPortfolioForecast(): Promise<Forecast | null> {
   return apiRequest<Forecast | null>("/api/market/forecast-portfolio");
+}
+
+/**
+ * Varlik kartindaki "Polifin AI Analizi" kutusu icin SSE akisi.
+ *
+ * ⚠️ `chatService.streamChat` ILE KARISTIRILMASIN: bu cagri HICBIR sohbet
+ * oturumu ACMAZ/KAYDETMEZ (bkz. routes/market.py::quick_analysis). Kart
+ * acildiginda `ChatContext`'e (widget ile PAYLASIMLI) DOKUNULMAMASI icin
+ * ozellikle ayri tutulur - aksi halde kullanicinin hic yazmadigi bir soru
+ * gercek sohbet gecmisinde beliriyordu.
+ */
+export function streamQuickAnalysis(
+  symbol: string,
+  onEvent: (event: ChatEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  return streamSse<ChatEvent>(
+    `/api/market/quick-analysis?symbol=${encodeURIComponent(symbol)}`,
+    onEvent,
+    { signal },
+  );
 }

--- a/frontend/src/services/sseStream.ts
+++ b/frontend/src/services/sseStream.ts
@@ -1,0 +1,57 @@
+import { getAccessToken, getApiUrl } from "./apiClient";
+
+/**
+ * Ortak SSE (Server-Sent Events) okuyucu.
+ *
+ * `chatService.ts::streamChat` ve `marketService.ts::streamQuickAnalysis`
+ * AYNI cerceve ayrimini (bosluklu iki satirla ayrilmis "data: {json}"
+ * bloklari) paylasir - kod burada TEK yerde tutulur, ikisi de bunu cagirir.
+ *
+ * Native `EventSource` KULLANILMAZ: yalnizca GET destekler ve
+ * `Authorization` header'i gonderemez (bkz. `chatService.ts` modul
+ * docstring'i, mimari v4 bolum 4.6) - bu yuzden `fetch` + `ReadableStream`
+ * ile elle ayristirilir.
+ */
+export async function streamSse<T>(
+  path: string,
+  onEvent: (event: T) => void,
+  options?: { method?: "GET" | "POST"; body?: unknown; signal?: AbortSignal },
+): Promise<void> {
+  const token = getAccessToken();
+  const response = await fetch(getApiUrl(path), {
+    method: options?.method ?? "GET",
+    headers: {
+      ...(options?.body ? { "Content-Type": "application/json" } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+    signal: options?.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error("Akış başlatılamadı.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+
+    for (const chunk of chunks) {
+      const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+      if (!dataLine) {
+        continue;
+      }
+      onEvent(JSON.parse(dataLine.slice(6)) as T);
+    }
+  }
+}

--- a/frontend/src/utils/tradeIntent.test.ts
+++ b/frontend/src/utils/tradeIntent.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import type { Asset } from "../models/market";
+import { parseTradeIntent, resolveAssetFromText } from "./tradeIntent";
+
+const KATALOG: Asset[] = [
+  {
+    symbol: "THYAO", name: "Türk Hava Yolları", asset_class: "STOCK", currency: "TRY",
+    current_price: 302.25, daily_change_pct: 1, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "ASELS", name: "Aselsan", asset_class: "STOCK", currency: "TRY",
+    current_price: 390.25, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "EREGL", name: "Erdemir", asset_class: "STOCK", currency: "TRY",
+    current_price: 36.44, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "NVDA", name: "Nvidia", asset_class: "USA_STOCK", currency: "USD",
+    current_price: 228.91, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "BTC", name: "Bitcoin", asset_class: "CRYPTO", currency: "USD",
+    current_price: 78242, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "USD/TRY", name: "Amerikan Doları", asset_class: "FOREX", currency: "TRY",
+    current_price: 48.24, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+  {
+    symbol: "KO", name: "Coca-Cola Company", asset_class: "USA_STOCK", currency: "USD",
+    current_price: 62.1, daily_change_pct: null, weekly_change_pct: null, yearly_change_pct: null,
+  },
+];
+
+describe("parseTradeIntent - yon tespiti", () => {
+  it.each([
+    "THYAO al",
+    "aselsan alalım",
+    "5 lot ereğli alacağım",
+    "bitcoin alıyorum",
+    // ⚠️ EN KRITIK TUZAK: "satın al" icinde "sat" gecer ama SATIM DEGILDIR.
+    "THYAO satın al",
+    "aselsan satın alalım",
+  ])("%s -> BUY", (metin) => {
+    expect(parseTradeIntent(metin)?.side).toBe("BUY");
+  });
+
+  it.each(["THYAO sat", "aselsan satalım", "3 lot ereğli satacağım", "bitcoin satıyorum"])(
+    "%s -> SELL",
+    (metin) => {
+      expect(parseTradeIntent(metin)?.side).toBe("SELL");
+    },
+  );
+});
+
+describe("parseTradeIntent - emir OLMAYAN cumleler", () => {
+  it.each([
+    // Tavsiye sorulari: kart cikarmak kullaniciyi isleme itmek olurdu.
+    "THYAO alsam mı",
+    "aselsan alınır mı",
+    "bitcoin almalı mıyım",
+    "şimdi satmalı mıyım",
+    // Fiil hic yok
+    "THYAO fiyatı ne kadar",
+    "portföyüm nasıl gidiyor",
+    "piyasada neler oluyor",
+    // Ikisi birden: "al sat" bir emir degil, genel bir ifade
+    "al sat sinyalleri nedir",
+    // Soru kalibi: bilgi talebi, emir degil - normal sohbete gitmeli.
+    "hisse alım maliyetim ne",
+    "kaç lot THYAO alabilirim",
+    "hangi hisseyi almalıyım",
+    "nasıl altın alınır",
+    "THYAO al?",
+    "",
+  ])("%s -> null", (metin) => {
+    expect(parseTradeIntent(metin)).toBeNull();
+  });
+
+  it("gunluk kelimeler yanlislikla fiil sanilmaz", () => {
+    // "altin", "analiz", "alan" kelimeleri "al" ile BASLAR ama fiil degildir.
+    expect(parseTradeIntent("altın analizi yap")).toBeNull();
+    expect(parseTradeIntent("bu alan ne anlama geliyor")).toBeNull();
+  });
+});
+
+describe("parseTradeIntent - adet ve tutar", () => {
+  it("acik adet okunur", () => {
+    expect(parseTradeIntent("5 lot THYAO al")).toMatchObject({ quantity: 5, amountTry: null });
+    expect(parseTradeIntent("3 adet aselsan al")).toMatchObject({ quantity: 3 });
+    expect(parseTradeIntent("2,5 gram altın al")).toMatchObject({ quantity: 2.5 });
+  });
+
+  it("TL tutari okunur", () => {
+    expect(parseTradeIntent("10 bin TL'lik THYAO al")).toMatchObject({
+      quantity: null,
+      amountTry: 10_000,
+    });
+    expect(parseTradeIntent("5000 TL değerinde bitcoin al")).toMatchObject({ amountTry: 5_000 });
+  });
+
+  it("adet varken sayi TUTAR sanilmaz", () => {
+    // ⚠️ "5 lot" -> adet 5; 5 TL butce DEGIL.
+    expect(parseTradeIntent("5 lot THYAO al")?.amountTry).toBeNull();
+  });
+
+  it("para birimi yoksa tutar okunmaz", () => {
+    // Ciplak sayi bir butce degildir - kullanicinin ne demek istedigi belirsiz,
+    // bu durumda nakde gore hesaplanan varsayilan adet kullanilir.
+    expect(parseTradeIntent("THYAO 1000 al")?.amountTry).toBeNull();
+  });
+});
+
+describe("resolveAssetFromText", () => {
+  it.each([
+    ["THYAO al", "THYAO"],
+    ["thyao al", "THYAO"],
+    ["aselsan al", "ASELS"],
+    ["nvidia al", "NVDA"],
+    ["bitcoin al", "BTC"],
+    // Kod + Turkce ek: katalogdaki ad "Erdemir" ama kullanici "ereğli" der.
+    ["ereğli al", "EREGL"],
+    ["ereğliden 5 lot al", "EREGL"],
+    // Ayirac karakterli kod, sikisik yazim
+    ["usdtry al", "USD/TRY"],
+    ["dolar al", "USD/TRY"],
+  ])("%s -> %s", (metin, beklenen) => {
+    expect(resolveAssetFromText(metin, KATALOG)?.symbol).toBe(beklenen);
+  });
+
+  it("katalogda olmayan varlik icin null doner", () => {
+    expect(resolveAssetFromText("tesla al", KATALOG)).toBeNull();
+    expect(resolveAssetFromText("bir seyler al", KATALOG)).toBeNull();
+  });
+
+  it("kisa kodlar yalnizca BUYUK HARFLE yazildiginda eslesir", () => {
+    // "ko" gunluk bir hece; kucuk harfle sembol sayilmamali.
+    expect(resolveAssetFromText("ko al", KATALOG)).toBeNull();
+    expect(resolveAssetFromText("KO al", KATALOG)?.symbol).toBe("KO");
+  });
+
+  it("esit guclu iki eslesmede cumlede ONCE gecen kazanir", () => {
+    // Ikisi de TAM kod eslesmesi (ayni puan) - siralamayi konum belirler.
+    expect(resolveAssetFromText("thyao ve asels al", KATALOG)?.symbol).toBe("THYAO");
+    expect(resolveAssetFromText("asels ve thyao al", KATALOG)?.symbol).toBe("ASELS");
+  });
+
+  it("TAM kod eslesmesi, ekli ad eslesmesini yener", () => {
+    // "aselsan" ASELS'e EKLI eslesir (puan 2), "thyao" TAM eslesir (puan 3);
+    // konumu sonra olsa bile tam eslesme kazanmali.
+    expect(resolveAssetFromText("aselsan ve thyao al", KATALOG)?.symbol).toBe("THYAO");
+  });
+});

--- a/frontend/src/utils/tradeIntent.ts
+++ b/frontend/src/utils/tradeIntent.ts
@@ -1,0 +1,232 @@
+/**
+ * Sohbete yazilan serbest metinden AL/SAT niyetini ve varligi cozer.
+ *
+ * NEDEN FRONTEND'DE (ve LLM'de degil): projede zaten ayni desen var -
+ * "yatirim yapmak istiyorum" akisi (`useInvestmentPackageFlow`) da niyeti
+ * YEREL yakalar, hicbir mesaj backend'e gitmez. Ayni yaklasim burada da
+ * secildi: emir onerisi para hareketi baslatan bir adim, LLM'in serbest
+ * yorumuna birakmak yerine ACIK ve ONGORULEBILIR kaliplarla tetiklenmesi
+ * tercih edildi. Kullanici yine de her emri karttan TEK TEK onaylar.
+ *
+ * ⚠️ SEMBOL COZUMU BACKEND'DEKININ SADELESTIRILMIS IKIZI. Asil/kalibre
+ * edilmis surum `app/agents/market_research.py::resolve_symbol`'dur; burada
+ * yalnizca en guclu iki katman (tam kod eslesmesi + kod/ad + Turkce ek)
+ * tekrarlanir. Ikisi ayrisirsa kullaniciya gorunen sonuc "varligi bulamadim"
+ * mesajidir - yanlis varlikta emir ONERILMEZ, cunku onerilen sembol her
+ * durumda katalogdan (`/api/market/assets`) gelir.
+ */
+
+import type { Asset } from "../models/market";
+import { parseBudgetInput } from "./budgetInput";
+
+export type TradeSide = "BUY" | "SELL";
+
+export type TradeIntent = {
+  side: TradeSide;
+  /** Acikca yazilmis adet ("5 lot", "3 adet") - yoksa `null`. */
+  quantity: number | null;
+  /** Acikca yazilmis TL butcesi ("10 bin TL'lik") - yoksa `null`. */
+  amountTry: number | null;
+};
+
+//: Turkce harfleri ASCII karsiliklarina cevirir (backend `_TR_TRANSLATION`
+//: ile ayni kume) - "ereğli" ile "eregli" ayni sekilde eslessin diye.
+const TR_MAP: Record<string, string> = {
+  ç: "c", ğ: "g", ı: "i", ö: "o", ş: "s", ü: "u",
+  Ç: "c", Ğ: "g", İ: "i", I: "i", Ö: "o", Ş: "s", Ü: "u",
+  â: "a", î: "i", û: "u",
+};
+
+export function normalizeTr(text: string): string {
+  return text.replace(/[çğıöşüÇĞİIÖŞÜâîû]/g, (ch) => TR_MAP[ch] ?? ch).toLowerCase();
+}
+
+//: ALIM fiilleri. "satin al" da buraya duser - `\b` sinirlari sayesinde
+//: "satin" SATIM desenine TAKILMAZ ("sat" tam kelime degil).
+const BUY_PATTERN =
+  /\b(?:satin\s+)?al(?:sana|alim|ayim|acagim|acaksin|iyorum|abilir|abilirsin|mak|im|ir)?\b/;
+
+//: SATIM fiilleri. "satin" bilerek KAPSAM DISI (bkz. yukarisi).
+const SELL_PATTERN =
+  /\bsat(?:sana|alim|ayim|acagim|acaksin|iyorum|abilir|abilirsin|mak|im|ar|is)?\b/;
+
+//: Tavsiye SORUSU kaliplari - emir onerisi URETILMEZ. "alsam mi", "alinir
+//: mi", "almali miyim" gibi sorular bir emir talebi degil, fikir sorusudur;
+//: bunlara kart cikarmak kullaniciyi islem yapmaya itmis olurdu.
+const ADVICE_QUESTION = /\b(mi|mu)\b/;
+
+//: Soru kelimeleri. Cumlede soru varsa bu bir EMIR degil bilgi
+//: talebidir: "hisse alim maliyetim ne" -> normal sohbete gitmeli,
+//: kart cikmamali. Bilincli olarak MUHAFAZAKAR - emin olmadigimiz
+//: cumleyi sohbete birakmak, kullanicinin istemedigi bir emir kartini
+//: onune koymaktan iyidir; emir isteyen net yazabilir ("5 lot THYAO al").
+const QUESTION_WORD =
+  /\b(ne|nedir|neden|niye|nicin|nasil|hangi|kac|kacta|kactan|kim|nerede)\b/;
+
+//: Adet ifadeleri: "5 lot", "3 adet", "2 tane", "10 hisse", "5 gram".
+const QUANTITY_PATTERN = /(\d+(?:[.,]\d+)?)\s*(?:lot|adet|tane|hisse|gram|birim)\b/;
+
+//: Tutar ifadesi sayilmasi icin metinde para birimi GECMELI - aksi halde
+//: "5 lot" ifadesindeki 5 butce sanilirdi.
+const CURRENCY_MARKER = /(₺|\btl\b|\btry\b|\blira)/;
+
+/**
+ * Mesajdan al/sat niyetini cikarir; emir kastedilmiyorsa `null`.
+ *
+ * Bilincli olarak MUHAFAZAKAR: yalnizca acik fiil kaliplari tetikler ve
+ * tavsiye sorulari ("alsam mi") DISLANIR.
+ */
+export function parseTradeIntent(raw: string): TradeIntent | null {
+  const text = normalizeTr(raw).trim();
+  if (!text) return null;
+
+  if (ADVICE_QUESTION.test(text) || QUESTION_WORD.test(text) || text.includes("?")) {
+    return null;
+  }
+
+  const buy = BUY_PATTERN.test(text);
+  const sell = SELL_PATTERN.test(text);
+  // Ikisi birden gecen cumle ("al sat sinyalleri nedir") bir emir degildir.
+  if (buy === sell) return null;
+
+  const quantityMatch = text.match(QUANTITY_PATTERN);
+  const quantity = quantityMatch ? Number(quantityMatch[1].replace(",", ".")) : null;
+
+  // Adet acikca yazildiysa tutar aranmaz: "5 lot" ifadesindeki 5, butce degil.
+  const amountTry =
+    quantity === null && CURRENCY_MARKER.test(text) ? parseBudgetInput(raw) : null;
+
+  return {
+    side: buy ? "BUY" : "SELL",
+    quantity: quantity !== null && Number.isFinite(quantity) && quantity > 0 ? quantity : null,
+    amountTry,
+  };
+}
+
+/** Sembolun ASCII/sikisik varyantlari: "USD/TRY" -> {"usd/try", "usdtry"}. */
+function symbolRoots(symbol: string): string[] {
+  const kok = normalizeTr(symbol);
+  const sikisik = kok.replace(/[^a-z0-9]/g, "");
+  return sikisik && sikisik !== kok ? [kok, sikisik] : [kok];
+}
+
+//: Kod/ad sonrasi kabul edilen Turkce ekler ("eregli" -> EREGL + "i",
+//: "ereğliden" -> EREGL + "iden"). Liste bilerek SONLU: acik uclu bir ek
+//: kurali ("3 harfe kadar her sey") gunluk kelimeleri sembol sanardi.
+const TR_SUFFIXES = new Set([
+  "", "i", "u", "a", "e", "n", "in", "un", "nin", "nun",
+  "den", "dan", "ten", "tan", "de", "da", "te", "ta",
+  "yi", "yu", "si", "su", "ni", "nu", "im", "an", "en",
+  "ler", "lar", "leri", "lari", "lerin", "larin",
+  // Kaynastirma unlusu + hal eki: "eregli-den", "aselsan-i-n"
+  "iden", "idan", "uden", "udan", "nden", "ndan",
+  "inden", "indan", "unden", "undan",
+  "ini", "ine", "ina", "unu", "una", "sini", "sinin", "sunu", "sunun",
+  "le", "la", "yle", "yla", "ile", "li", "lu", "lik", "luk",
+]);
+
+//: Kullanicinin gunluk dilde kullandigi ama katalog ADIYLA eslesmeyen
+//: isimler. Backend'deki `_SEMBOL_TAKMA_ADLARI` ile AYNI kume - orada
+//: gerekcesi tek tek yazili (orn. USD/TRY'nin adi "Amerikan Dolari", ilk
+//: kelimesi "amerikan"; kullanici ise "dolar" der).
+const ALIASES: Record<string, string> = {
+  dolar: "USD/TRY", dolari: "USD/TRY", dolarin: "USD/TRY",
+  usd: "USD/TRY", usdtry: "USD/TRY",
+  eur: "EUR/TRY", eurtry: "EUR/TRY", eurosu: "EUR/TRY", euronun: "EUR/TRY",
+  altin: "GRAM_ALTIN", altini: "GRAM_ALTIN", altinin: "GRAM_ALTIN",
+  gumusu: "GUMUS", gumusun: "GUMUS",
+  bim: "BIMAS", bimin: "BIMAS",
+  koc: "KCHOL", kocun: "KCHOL",
+  lilly: "LLY", thy: "THYAO",
+  petrol: "BRENT", petrolu: "BRENT", petrolun: "BRENT",
+  berkshire: "BRK-B", coca: "KO", cola: "KO", att: "T",
+  tahvil: "US10Y", tahvili: "US10Y", tahvilin: "US10Y",
+};
+
+function matchesWithSuffix(token: string, kok: string): boolean {
+  return token.startsWith(kok) && TR_SUFFIXES.has(token.slice(kok.length));
+}
+
+/**
+ * Metindeki varligi KATALOGDAN cozer; tahmin uretmez.
+ *
+ * Katalogda gercekten var olan bir sembolle eslesmezse `null` doner - boylece
+ * "HISSE" gibi uydurma bir kodla emir onerilmesi YAPISAL OLARAK imkansizdir.
+ */
+export function resolveAssetFromText(raw: string, assets: Asset[]): Asset | null {
+  const text = normalizeTr(raw);
+  const tokens = text.match(/[a-z0-9]+/g) ?? [];
+  if (tokens.length === 0) return null;
+
+  // (puan, konum) - once puan (tam eslesme > ekli eslesme), esitlikte
+  // cumlede ONCE gecen kazanir.
+  let best: { asset: Asset; score: number; position: number } | null = null;
+
+  const consider = (asset: Asset, score: number, position: number) => {
+    if (
+      best === null ||
+      score > best.score ||
+      (score === best.score && position < best.position)
+    ) {
+      best = { asset, score, position };
+    }
+  };
+
+  for (const asset of assets) {
+    const roots = symbolRoots(asset.symbol);
+    // Cok kisa kodlar (KO, T) gunluk kelimelerle cakisir; yalnizca HAM
+    // metinde BUYUK HARFLE tam kelime olarak yazildiysa kabul edilir.
+    if (asset.symbol.replace(/[^A-Za-z0-9]/g, "").length < 3) {
+      const strict = new RegExp(`(?<![A-Za-z0-9])${asset.symbol}(?![A-Za-z0-9])`);
+      if (strict.test(raw)) consider(asset, 3, raw.indexOf(asset.symbol));
+      continue;
+    }
+
+    let matched = false;
+    tokens.forEach((token, index) => {
+      if (matched) return;
+      if (roots.includes(token)) {
+        consider(asset, 3, index);
+        matched = true;
+      } else if (roots.some((kok) => matchesWithSuffix(token, kok))) {
+        consider(asset, 2, index);
+        matched = true;
+      }
+    });
+    if (matched) continue;
+
+    const name = normalizeTr(asset.name).trim();
+    if (name && text.includes(name)) {
+      consider(asset, 3, text.indexOf(name));
+      continue;
+    }
+    // Adin ilk kelimesi ("aselsan", "erdemir") - kisa kelimeler (\"bim\")
+    // gunluk dille cakismasin diye en az 5 harf istenir.
+    const firstWord = name.split(/\s+/)[0] ?? "";
+    if (firstWord.length >= 5) {
+      tokens.forEach((token, index) => {
+        if (matched) return;
+        if (matchesWithSuffix(token, firstWord)) {
+          consider(asset, 2, index);
+          matched = true;
+        }
+      });
+    }
+  }
+
+  // TAKMA ADLAR EN SON denenir: gercek bir kod/ad eslesmesi bulunduysa o
+  // kazanmali (backend `resolve_symbol` ile ayni sira).
+  if (best === null) {
+    for (const [index, token] of tokens.entries()) {
+      const symbol = ALIASES[token];
+      if (!symbol) continue;
+      const asset = assets.find((item) => item.symbol.toUpperCase() === symbol);
+      if (asset) {
+        consider(asset, 2, index);
+        break;
+      }
+    }
+  }
+
+  return best ? (best as { asset: Asset }).asset : null;
+}


### PR DESCRIPTION
## Ne yapıldı

- Varlık ticker'ından bir sembole tıklayınca açılan "AI Analizi" kutusu artık kullanıcının **gerçek sohbet geçmişine karışmıyor** (yeni, kalıcı oturum açmayan `/api/market/quick-analysis` ucu). Ayrıca bu kutunun React StrictMode kaynaklı "Analiz hazırlanıyor…" da sonsuza dek takılı kalma hatası düzeltildi.
- Sohbette bir varlık sorulduğunda, cevap metninde hiç bahsedilmeyen portföy "günün hareketlileri" kartlarının sızması (alakasız varlık kartları) giderildi.
- **Çoklu varlık desteği**: "NVIDIA ve Apple ne durumda" gibi sorularda artık yalnızca ilk varlık değil, ikinci/üçüncü varlık da hem kart olarak gösteriliyor hem cevap metninde bahsediliyor. Kod+Türkçe ek eşleştirmesi de eklendi (örn. "ereğli" → EREGL, veritabanında adı "Erdemir" olsa bile).
- **Yeni özellik (TC-020/US14)**: Sohbete "THYAO al", "5 lot ASELS al", "10 bin TL'lik bitcoin al", "EREGL sat" gibi yazınca, mesaj backend'e/LLM'e gitmeden yerel bir **emir onay kartına** dönüşüyor. Kart adet/fiyat/komisyon/toplam/işlem sonrası nakit gösteriyor; Onayla/Düzenle/İptal ile tek tıkla işleme alınabiliyor. Rakamların tamamı backend önizlemesinden geliyor, istemci hiçbir tutar hesaplamıyor.

## İlgili gereksinim / görev

TC-020 – US14: Chatbot Üzerinden İşlem Onaylama

## Nasıl test edildi

- Backend: yeni testler dahil ilgili test dosyaları çalıştırıldı, hepsi geçti (leads/CRM modülündeki 2 önceden var olan, bu değişikliklerle ilgisiz test hariç).
- Frontend: `tsc --noEmit` temiz, 69 test geçti (42'si yeni emir ayrıştırıcısı için: yön tespiti, "satın al" tuzağı, tavsiye soruları, adet/tutar okuma, sembol çözümleme).
- Tarayıcıda elle test edildi: varlık kartı analizi artık sohbete sızmıyor, çoklu varlık soruları doğru kart/metin üretiyor, "5 lot THYAO al" akışı uçtan uca denendi.

## Kontrol listesi

- [x] CI yeşil (local: pytest, tsc, vitest)
- [ ] Yeni env değişkeni yok
- [x] Gizli bilgi (API key, şifre) commit edilmedi
- [x] Kod içi Türkçe docstring/yorumlarla belgelendi